### PR TITLE
TableReplicator 0.2.7

### DIFF
--- a/lib/tablereplicator/src/Server/ServerTableReplicator.luau
+++ b/lib/tablereplicator/src/Server/ServerTableReplicator.luau
@@ -485,7 +485,9 @@ end
     Destroys the Replicator on both the Server and any replicated Clients
 ]=]
 function ServerTableReplicator:Destroy()
-    self:SetReplicationTargets({})
+    if self:IsTopLevel() then
+        self:SetReplicationTargets({})
+    end
     getmetatable(ServerTableReplicator).Destroy(self)
 end
 
@@ -534,8 +536,6 @@ function ServerTableReplicator:_InitListeners()
         end
     end)
 end
-
-
 
 --[=[
     @private

--- a/lib/tablereplicator/wally.toml
+++ b/lib/tablereplicator/wally.toml
@@ -2,7 +2,7 @@
 name = "raild3x/tablereplicator"
 description = "A set of classes for replicating tables and their changes between server and client with minimal effort."
 authors = ["Logan Hunt (Raildex)"]
-version = "0.2.6"
+version = "0.2.7"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
This pull request introduces a minor version bump to `tablereplicator` and includes a small fix to the `ServerTableReplicator` class to ensure replication targets are cleared only for top-level replicators. Additionally, some unnecessary blank lines have been removed for code cleanliness.

Version update:

* Bumped the package version from `0.2.6` to `0.2.7` in `wally.toml` to reflect the new changes.

Bug fix and code cleanup:

* Updated `ServerTableReplicator:Destroy()` to only clear replication targets if the instance is top-level, preventing unintended behavior for nested replicators.
* Removed redundant blank lines from the `_InitListeners` method for improved readability.