### PR TITLE
Ensure Janitors are cleaned up prior to scopes | BaseComponent_v0.1.2

### DIFF
--- a/lib/basecomponent/src/ComponentFusionUtil.luau
+++ b/lib/basecomponent/src/ComponentFusionUtil.luau
@@ -21,6 +21,7 @@ local Packages = script.Parent.Parent
 local RailUtil = require(Packages.RailUtil)
 local Symbol = require(Packages.Symbol)
 local Fusion = require(Packages.Fusion)
+local ComponentJanitorUtil = require(script.Parent.ComponentJanitorUtil); ---@module ComponentJanitorUtil
 
 --// Constants //--
 local KEY_SCOPE = Symbol("Fusion Scope")
@@ -56,16 +57,17 @@ local UtilMethods = {
     --// Extension //--
 --------------------------------------------------------------------------------
 
-local ComponentJanitorUtilExtension = {}
-ComponentJanitorUtilExtension.ClassName = "ComponentFusionUtil"
-ComponentJanitorUtilExtension.Methods = UtilMethods
+local ComponentFusionUtilExtension = {}
+ComponentFusionUtilExtension.ClassName = "ComponentFusionUtil"
+ComponentFusionUtilExtension.Methods = UtilMethods
+ComponentFusionUtilExtension.Extensions = {}
 
 --[=[
     @within ComponentFusionUtil
     @ignore
     @param component any
 ]=]
-function ComponentJanitorUtilExtension.Constructing(component)
+function ComponentFusionUtilExtension.Constructing(component)
     component[KEY_SCOPE] = RailUtil.Fusion.scoped()
     component.Scope = component[KEY_SCOPE]
 end
@@ -75,11 +77,12 @@ end
     @ignore
     @param component any
 ]=]
-function ComponentJanitorUtilExtension.Stopped(component)
+function ComponentFusionUtilExtension.Stopped(component)
+    ComponentJanitorUtil.Stopped(component) -- Ensure janitor cleans first
     component[KEY_SCOPE]:doCleanup()
     component[KEY_SCOPE] = nil
 end
 
 
 
-return ComponentJanitorUtilExtension
+return ComponentFusionUtilExtension

--- a/lib/basecomponent/src/ComponentJanitorUtil.luau
+++ b/lib/basecomponent/src/ComponentJanitorUtil.luau
@@ -139,8 +139,13 @@ end
     @param component any
 ]=]
 function ComponentJanitorUtilExtension.Stopped(component)
-    component[JANITOR]:Destroy()
-    component[JANITOR] = nil
+    if component[JANITOR] then
+        task.spawn(function()
+            -- Janitor runs synchronously, so to prevent any issues we spawn a new thread.
+            component[JANITOR]:Destroy()
+        end)
+        component[JANITOR] = nil
+    end
 end
 
 

--- a/lib/basecomponent/wally.toml
+++ b/lib/basecomponent/wally.toml
@@ -2,7 +2,7 @@
 name = "raild3x/basecomponent"
 description = "A utility extension to provide helpers for working with signals, janitors, attributes, and properties. *Only works with my Component fork.*"
 authors = ["Logan Hunt (Raildex)"]
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
Renamed ComponentJanitorUtilExtension to ComponentFusionUtilExtension and updated method references for clarity. Improved janitor cleanup in ComponentJanitorUtil to run asynchronously for safer resource management. Bumped package version to 0.1.2 in wally.toml.