### PR TITLE
Fix object retrieval logic | ObjectCachev0.0.2

### DIFF
--- a/lib/objectcache/src/init.lua
+++ b/lib/objectcache/src/init.lua
@@ -185,8 +185,6 @@ function ObjectCache:_GetNew(Amount: number, Warn: boolean)
 	for _, Object in AddedObjects do
 		(Object:: Instance).Parent = CacheHolder
 	end
-
-	return self._FreeObjects[InitialLength + Amount]
 end
 
 --[=[
@@ -197,7 +195,10 @@ end
     :::
 ]=]
 function ObjectCache:Get<T>(moveTo: CFrame?): T
-	local obj = table.remove(self._FreeObjects) or self:_GetNew(self._ExpandAmount, true)
+    if #self._FreeObjects == 0 then
+        self:_GetNew(self._ExpandAmount, true)
+    end
+	local obj = table.remove(self._FreeObjects)
 
 	self._InUseObjects[obj] = true
 

--- a/lib/objectcache/wally.toml
+++ b/lib/objectcache/wally.toml
@@ -2,7 +2,7 @@
 name = "raild3x/objectcache"
 description = "A fork of Pyseph's ObjectCache module, with some additional features."
 authors = ["Logan Hunt (Raildex)"]
-version = "0.0.1"
+version = "0.0.2"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
Corrects the logic in ObjectCache:Get to ensure new objects are added when the cache is empty, preventing nil returns. Also updates the wally.toml version to 0.0.2.