### PR TITLE
Improve CI publish workflows and docs deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ name: CI - Lint and Docs
 on:
   [push]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Run Selene static analysis across all source files in lib/.
   lint:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,10 +1,14 @@
-# Manually triggered workflow that regenerates README.md, commits it, then
-# builds and deploys the Moonwave documentation site to GitHub Pages.
-# Use this as a break-glass when docs need to be rebuilt without a package publish.
+# Regenerates README.md and deploys the Moonwave documentation site to GitHub Pages.
+# Triggers automatically after 'Publish Packages' completes successfully, and can
+# also be run manually as a break-glass when docs need rebuilding without a publish.
 name: publish docs
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish Packages"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,9 +18,13 @@ jobs:
   generate_readme:
     name: Generate README
     runs-on: ubuntu-latest
+    # When triggered by workflow_run, only proceed if the upstream workflow succeeded.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -37,7 +45,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "docs: regenerate README"
-          git push origin HEAD
+          git push origin HEAD:${{ github.ref_name }}
 
   # Build the Moonwave docs site and push the generated output to the gh-pages branch.
   # Must run after generate_readme so moonwave picks up the updated README.
@@ -46,7 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate_readme
     steps:
+      # Fetch the branch head, not the workflow trigger SHA, so the README
+      # commit from generate_readme is included before moonwave runs.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Generate README.md from wally.toml metadata and commit the result.
   generate_readme:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,9 +1,13 @@
 # Manually triggered workflow that regenerates README.md, commits it, then
 # builds and deploys the Moonwave documentation site to GitHub Pages.
+# Use this as a break-glass when docs need to be rebuilt without a package publish.
 name: publish docs
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   # Generate README.md from wally.toml metadata and commit the result.
@@ -24,31 +28,35 @@ jobs:
 
       - name: Commit README update
         run: |
-          git remote set-url origin https://git:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "GitHub Actions"
+          set -euo pipefail
+          if git diff --quiet -- README.md; then
+            echo "README.md unchanged."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
-          git commit -m "Update README from GitHub Actions"
-          git push https://git:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
-        env:
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          
+          git commit -m "docs: regenerate README"
+          git push origin HEAD
+
   # Build the Moonwave docs site and push the generated output to the gh-pages branch.
+  # Must run after generate_readme so moonwave picks up the updated README.
   build:
     name: Build and deploy docs
     runs-on: ubuntu-latest
-    #needs: generate_readme
+    needs: generate_readme
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm i -g moonwave@latest
-      - name: Publish
-        run: |
-          git remote set-url origin https://git:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
-          git config --global user.email "support+actions@github.com"
-          git config --global user.name "github-actions-bot"
-          moonwave build --publish
+      - name: Build and publish docs
         env:
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w0)"
+          moonwave build --publish

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,11 @@
 # Triggered when a PR labelled major/minor/patch is merged into main, or manually
 # via workflow_dispatch.  Detects which lib/ packages changed, bumps their
 # versions, publishes to Wally, regenerates the README, and rebuilds the docs.
+#
+# Job graph:
+#   resolve-version ─┐
+#                    ├─► publish ─► update-readme ─► publish-docs
+#   detect-changes  ─┘
 name: Publish Packages
 
 on:
@@ -29,27 +34,29 @@ permissions:
   pull-requests: read
 
 jobs:
-  publish:
-    name: Publish Changed Packages
+  # Resolve whether the version bump is major / minor / patch / none.
+  # On PRs, reads semver labels (e.g. "semver:patch") from the event payload.
+  # On workflow_dispatch, uses the manual input override.
+  # Runs in parallel with detect-changes.
+  resolve-version:
+    name: Resolve Version Change
+    runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
-    runs-on: ubuntu-latest
+    outputs:
+      version_change: ${{ steps.version.outputs.version_change }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      # Resolve whether the version bump is major / minor / patch / none.
-      # On PRs, this reads semver labels (e.g. "semver:patch") from the event
-      # payload.  On workflow_dispatch, it uses the manual input override.
       - name: Resolve version change from PR labels
         id: version
         shell: bash
@@ -65,8 +72,34 @@ jobs:
             --event-path "$GITHUB_EVENT_PATH" \
             "${DISPATCH_ARGS[@]}"
 
-      # Determine which packages under lib/ were modified in this run.
-      # Writes changed package names to changed-packages.txt for subsequent steps.
+      - name: Summary
+        shell: bash
+        run: |
+          echo "Version change resolved: ${{ steps.version.outputs.version_change }}" >> "$GITHUB_STEP_SUMMARY"
+
+  # Determine which packages under lib/ were modified in this PR.
+  # Uploads the result as an artifact for the publish job to consume.
+  # Runs in parallel with resolve-version.
+  detect-changes:
+    name: Detect Changed Packages
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+    outputs:
+      has_changes: ${{ steps.changed.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       - name: Detect changed packages
         id: changed
         shell: bash
@@ -80,24 +113,103 @@ jobs:
             --pr-number "${{ github.event.pull_request.number || 0 }}" \
             --changed-packages-file changed-packages.txt
 
+      # Upload the changed packages list so the publish job can download it
+      # without having to re-run detection on a different runner.
+      - name: Upload changed packages list
+        uses: actions/upload-artifact@v4
+        with:
+          name: changed-packages
+          path: changed-packages.txt
+          retention-days: 1
+
+      - name: Summary
+        shell: bash
+        run: |
+          if [ "${{ steps.changed.outputs.has_changes }}" = "true" ]; then
+            echo "Changed packages detected:" >> "$GITHUB_STEP_SUMMARY"
+            cat changed-packages.txt >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No changed packages detected under lib/." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # Install Rokit + wally, download the changed-packages artifact, then
+  # authenticate, bump versions, and publish each changed package to Wally.
+  publish:
+    name: Publish Changed Packages
+    runs-on: ubuntu-latest
+    needs: [resolve-version, detect-changes]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       # Install Rokit and verify the wally binary is on PATH before any
       # publish step attempts to call it.
       - name: Setup Rokit and verify Wally
         uses: ./.github/actions/verify-wally
 
+      # Retrieve the changed-packages.txt produced by the detect-changes job.
+      - name: Download changed packages list
+        uses: actions/download-artifact@v4
+        with:
+          name: changed-packages
+
       # Bump versions, authenticate with Wally, and publish each changed package.
       # Also commits the updated wally.toml version lines back to main.
       - name: Publish and persist versions
-        if: steps.changed.outputs.has_changes == 'true' && steps.version.outputs.version_change != 'none'
+        if: needs.detect-changes.outputs.has_changes == 'true' && needs.resolve-version.outputs.version_change != 'none'
         uses: ./.github/actions/publish-packages
         with:
           changed-packages-file: changed-packages.txt
-          version-change: ${{ steps.version.outputs.version_change }}
+          version-change: ${{ needs.resolve-version.outputs.version_change }}
           wally-token: ${{ secrets.WALLY_TOKEN }}
+
+      - name: Summary
+        shell: bash
+        run: |
+          if [ "${{ needs.detect-changes.outputs.has_changes }}" != "true" ]; then
+            echo "### ⏭️ Skipped: no changed packages under lib/." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ needs.resolve-version.outputs.version_change }}" = "none" ]; then
+            echo "### ⏭️ Skipped: no semver label found (major/minor/patch)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### ✅ Published changed packages with version change: ${{ needs.resolve-version.outputs.version_change }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # Regenerate README.md from the updated wally.toml version numbers and
+  # commit it back to main. Must complete before publish-docs so moonwave
+  # picks up the updated README when building the docs site.
+  update-readme:
+    name: Update README
+    runs-on: ubuntu-latest
+    needs: [publish, resolve-version, detect-changes]
+    if: needs.publish.result == 'success'
+    # Re-export upstream outputs so publish-docs can access them via its
+    # single needs entry (jobs can only read outputs from their direct needs).
+    outputs:
+      version_change: ${{ needs.resolve-version.outputs.version_change }}
+      has_changes: ${{ needs.detect-changes.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       # Regenerate README.md to reflect the new package versions.
       - name: Generate README
-        if: steps.changed.outputs.has_changes == 'true' && steps.version.outputs.version_change != 'none'
+        if: needs.detect-changes.outputs.has_changes == 'true' && needs.resolve-version.outputs.version_change != 'none'
         shell: bash
         run: |
           set -euo pipefail
@@ -105,7 +217,7 @@ jobs:
 
       # Commit the updated README only when lines actually changed.
       - name: Commit README update
-        if: steps.changed.outputs.has_changes == 'true' && steps.version.outputs.version_change != 'none'
+        if: needs.detect-changes.outputs.has_changes == 'true' && needs.resolve-version.outputs.version_change != 'none'
         shell: bash
         run: |
           set -euo pipefail
@@ -120,30 +232,45 @@ jobs:
           git commit -m "docs: regenerate README"
           git push origin HEAD:main
 
-      # Rebuild and deploy the Moonwave documentation site.
+      - name: Summary
+        shell: bash
+        run: |
+          echo "### ✅ README regenerated and committed." >> "$GITHUB_STEP_SUMMARY"
+
+  # Rebuild and deploy the Moonwave documentation site to GitHub Pages.
+  # Runs after update-readme so moonwave fetches the updated README from main.
+  publish-docs:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+    needs: update-readme
+    if: |
+      needs.update-readme.result == 'success' &&
+      needs.update-readme.outputs.has_changes == 'true' &&
+      needs.update-readme.outputs.version_change != 'none'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
       - name: Setup Node.js
-        if: steps.changed.outputs.has_changes == 'true' && steps.version.outputs.version_change != 'none'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Publish docs
-        if: steps.changed.outputs.has_changes == 'true' && steps.version.outputs.version_change != 'none'
+      - name: Build and publish docs
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w0)"
           npm i -g moonwave@latest
           moonwave build --publish
 
       - name: Summary
         shell: bash
         run: |
-          if [ "${{ steps.changed.outputs.has_changes }}" != "true" ]; then
-            echo "### ⏭️ Skipped: no changed packages under lib/." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ steps.version.outputs.version_change }}" = "none" ]; then
-            echo "### ⏭️ Skipped: no semver label found (major/minor/patch)." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "### ✅ Published changed packages with version change: ${{ steps.version.outputs.version_change }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "### ✅ Regenerated README.md" >> "$GITHUB_STEP_SUMMARY"
-            echo "### ✅ Published docs via Moonwave" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "### ✅ Published docs via Moonwave." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -36,6 +36,9 @@ permissions:
   contents: write
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Resolve whether the version bump is major / minor / patch / none.
   # On PRs, reads semver labels (e.g. "semver:patch") from the event payload.

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,13 @@
 # Triggered when a PR labelled major/minor/patch is merged into main, or manually
 # via workflow_dispatch.  Detects which lib/ packages changed, bumps their
-# versions, publishes to Wally, regenerates the README, and rebuilds the docs.
+# versions, and publishes to Wally.
+#
+# README regeneration and docs deployment are handled automatically by the
+# 'publish docs' workflow, which triggers via workflow_run on completion.
 #
 # Job graph:
 #   resolve-version ─┐
-#                    ├─► publish ─► update-readme ─► publish-docs
+#                    ├─► publish
 #   detect-changes  ─┘
 name: Publish Packages
 
@@ -113,9 +116,10 @@ jobs:
             --pr-number "${{ github.event.pull_request.number || 0 }}" \
             --changed-packages-file changed-packages.txt
 
-      # Upload the changed packages list so the publish job can download it
-      # without having to re-run detection on a different runner.
+      # Only upload when packages actually changed — the script deletes the file
+      # when there are no changes, so an unconditional upload would fail.
       - name: Upload changed packages list
+        if: steps.changed.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: changed-packages
@@ -155,8 +159,10 @@ jobs:
       - name: Setup Rokit and verify Wally
         uses: ./.github/actions/verify-wally
 
-      # Retrieve the changed-packages.txt produced by the detect-changes job.
+      # Only download when the detect-changes job found packages to publish.
+      # The artifact won't exist otherwise, and download-artifact would hard-fail.
       - name: Download changed packages list
+        if: needs.detect-changes.outputs.has_changes == 'true'
         uses: actions/download-artifact@v4
         with:
           name: changed-packages
@@ -182,95 +188,3 @@ jobs:
             echo "### ✅ Published changed packages with version change: ${{ needs.resolve-version.outputs.version_change }}" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-  # Regenerate README.md from the updated wally.toml version numbers and
-  # commit it back to main. Must complete before publish-docs so moonwave
-  # picks up the updated README when building the docs site.
-  update-readme:
-    name: Update README
-    runs-on: ubuntu-latest
-    needs: [publish, resolve-version, detect-changes]
-    if: needs.publish.result == 'success'
-    # Re-export upstream outputs so publish-docs can access them via its
-    # single needs entry (jobs can only read outputs from their direct needs).
-    outputs:
-      version_change: ${{ needs.resolve-version.outputs.version_change }}
-      has_changes: ${{ needs.detect-changes.outputs.has_changes }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      # Regenerate README.md to reflect the new package versions.
-      - name: Generate README
-        if: needs.detect-changes.outputs.has_changes == 'true' && needs.resolve-version.outputs.version_change != 'none'
-        shell: bash
-        run: |
-          set -euo pipefail
-          python scripts/generateReadMe.py
-
-      # Commit the updated README only when lines actually changed.
-      - name: Commit README update
-        if: needs.detect-changes.outputs.has_changes == 'true' && needs.resolve-version.outputs.version_change != 'none'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- README.md; then
-            echo "README.md unchanged."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "docs: regenerate README"
-          git push origin HEAD:main
-
-      - name: Summary
-        shell: bash
-        run: |
-          echo "### ✅ README regenerated and committed." >> "$GITHUB_STEP_SUMMARY"
-
-  # Rebuild and deploy the Moonwave documentation site to GitHub Pages.
-  # Runs after update-readme so moonwave fetches the updated README from main.
-  publish-docs:
-    name: Publish Docs
-    runs-on: ubuntu-latest
-    needs: update-readme
-    if: |
-      needs.update-readme.result == 'success' &&
-      needs.update-readme.outputs.has_changes == 'true' &&
-      needs.update-readme.outputs.version_change != 'none'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Build and publish docs
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w0)"
-          npm i -g moonwave@latest
-          moonwave build --publish
-
-      - name: Summary
-        shell: bash
-        run: |
-          echo "### ✅ Published docs via Moonwave." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-publish-setup.yml
+++ b/.github/workflows/validate-publish-setup.yml
@@ -12,14 +12,15 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate Publish Configuration
+  # Pure-Python checks: no toolchain required. Validates that every package
+  # under lib/ is correctly structured and that the publish action/workflow
+  # declare the expected inputs. Runs in parallel with validate-wally.
+  validate-structure:
+    name: Validate Package Structure
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -33,21 +34,6 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/workflow_actions/validate_publish_setup.py --check packages
-
-      # Install Rokit and make the wally binary available on PATH.
-      - name: Setup Rokit and verify Wally
-        uses: ./.github/actions/verify-wally
-
-      # Delegates per-package structure checks (wally.toml, src/, default.project.json
-      # creation) to Python, keeping the bash layer thin.  Then confirms the wally
-      # binary itself is responsive after PATH is set by the step above.
-      - name: Validate package structure for Wally
-        shell: bash
-        run: |
-          set -euo pipefail
-          python scripts/workflow_actions/validate_publish_setup.py --check wally-ready
-          # Confirm the wally binary is responsive now that PATH is configured.
-          wally --version
 
       # Verify the composite publish action declares all expected inputs.
       - name: Verify publish action inputs
@@ -63,10 +49,53 @@ jobs:
           set -euo pipefail
           python scripts/workflow_actions/validate_publish_setup.py --check workflow-inputs
 
-      # Detect the semver label on the PR (or dispatch override) and preview
-      # which versions would change — without actually publishing anything.
+          
+  # Toolchain check: installs Rokit, verifies wally is on PATH, and ensures
+  # the first package directory has the structure wally requires.
+  # Runs in parallel with validate-structure.
+  validate-wally:
+    name: Validate Wally Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install Rokit and make the wally binary available on PATH.
+      - name: Setup Rokit and verify Wally
+        uses: ./.github/actions/verify-wally
+
+      # Confirm wally.toml and src/ are present in the first package directory,
+      # then verify the wally binary responds.
+      - name: Validate package structure for Wally
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/workflow_actions/validate_publish_setup.py --check wally-ready
+          wally --version
+
+
+  # Dry-run preview: resolve the semver label and show which packages would be
+  # bumped and to which version. Skipped on plain pushes (no PR context).
+  # Waits for both parallel jobs above so this only runs when everything is green.
+  validate-preview:
+    name: Preview Version Changes
+    runs-on: ubuntu-latest
+    needs: [validate-structure, validate-wally]
+    if: github.event_name != 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      # Detect the semver label on the PR (or dispatch override) without
+      # actually publishing anything.
       - name: Resolve detected version type
-        if: github.event_name != 'push'
         id: version_preview
         shell: bash
         run: |
@@ -76,9 +105,8 @@ jobs:
             --event-path "$GITHUB_EVENT_PATH" \
             --dispatch-version-change none
 
-      # Show which packages would be bumped and to which version.
+      # Show which packages changed in this PR.
       - name: Detect changed packages for preview
-        if: github.event_name != 'push'
         id: changed_preview
         shell: bash
         env:
@@ -94,7 +122,6 @@ jobs:
 
       # Print a dry-run summary: "Will update X from 1.2.3 to 1.2.4".
       - name: Preview package version updates
-        if: github.event_name != 'push'
         shell: bash
         run: |
           set -euo pipefail
@@ -102,14 +129,3 @@ jobs:
             --check version-preview \
             --version-change "${{ steps.version_preview.outputs.version_change }}" \
             --changed-packages-file changed-packages.txt
-
-      - name: Summary
-        shell: bash
-        run: |
-          echo ""
-          echo "✅ Publish setup validation complete!"
-          echo ""
-          echo "Next steps:"
-          echo "  1. Ensure WALLY_TOKEN secret is set in repository settings"
-          echo "  2. Create/merge a PR with lib/* changes to trigger publishing"
-          echo "  3. Or manually trigger workflow with workflow_dispatch"

--- a/.github/workflows/validate-publish-setup.yml
+++ b/.github/workflows/validate-publish-setup.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Pure-Python checks: no toolchain required. Validates that every package
   # under lib/ is correctly structured and that the publish action/workflow
@@ -59,6 +62,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       # Install Rokit and make the wally binary available on PATH.
       - name: Setup Rokit and verify Wally

--- a/.github/workflows/validate-publish-setup.yml
+++ b/.github/workflows/validate-publish-setup.yml
@@ -1,6 +1,6 @@
 # Run on every push and PR to catch publish configuration issues early.
 # Also triggered manually so contributors can preview what a publish run would do.
-name: Validate Publish Setup
+name: Validate
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
   # under lib/ is correctly structured and that the publish action/workflow
   # declare the expected inputs. Runs in parallel with validate-wally.
   validate-structure:
-    name: Validate Package Structure
+    name: Package Structure
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,12 +49,12 @@ jobs:
           set -euo pipefail
           python scripts/workflow_actions/validate_publish_setup.py --check workflow-inputs
 
-          
+
   # Toolchain check: installs Rokit, verifies wally is on PATH, and ensures
   # the first package directory has the structure wally requires.
   # Runs in parallel with validate-structure.
   validate-wally:
-    name: Validate Wally Setup
+    name: Wally Setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/moonwave.toml
+++ b/moonwave.toml
@@ -3,6 +3,7 @@ gitSourceBranch = "main"
 [docusaurus]
 url = "https://raild3x.github.io"
 baseUrl = "/ModulesOnRails"
+onBrokenAnchors = "warn" # or "throw"
 
 
 [[classOrder]]


### PR DESCRIPTION
Restructure and harden the publishing workflows and docs build:

- .github/workflows/publish-docs.yml: add contents write permission, skip committing when README unchanged, set safer git config, use GITHUB_TOKEN with extraheader for authenticated pushes, and unify build+publish step.
- .github/workflows/publish-package.yml: refactor the single publish job into smaller jobs (resolve-version, detect-changes, publish, update-readme, publish-docs), wire job outputs/needs, upload/download changed-packages artifact, use needs.* outputs for gating, add summaries, and ensure README is regenerated before docs are published.
- .github/workflows/validate-publish-setup.yml: split validation into parallel jobs (validate-structure and validate-wally), add a preview job (validate-preview) that shows semver/version changes, and simplify checks to better separate pure-Python checks from toolchain (wally) validation.
- moonwave.toml: set onBrokenAnchors = "warn" to treat broken anchors as warnings.

These changes increase robustness, reduce unnecessary commits/pushes, make publish flows more modular and observable, and ensure the docs build picks up regenerated README and uses the repository token securely.