### PR TITLE
Refactor TableManager profiling and enhance performance documentation

### DIFF
--- a/lib/tablemanager/src/Diffing/ChangeDetector.luau
+++ b/lib/tablemanager/src/Diffing/ChangeDetector.luau
@@ -304,8 +304,6 @@ function ChangeDetector.CaptureSnapshot(self: CD_Internal, rootTable: { [any]: a
 		print("  path:", table.concat(path, "."))
 		print("  rootTable type:", type(rootTable))
 	end
-	debug.profilebegin("CD:CaptureSnapshot")
-
 	-- Navigate to the value at the path
 	local valueAtPath = rootTable
 	for _, key in ipairs(path) do
@@ -323,7 +321,6 @@ function ChangeDetector.CaptureSnapshot(self: CD_Internal, rootTable: { [any]: a
 		Timestamp = os.clock(),
 	}
 
-	debug.profileend()
 	return snapshot
 end
 
@@ -437,10 +434,8 @@ function ChangeDetector.CheckForChangesBetween(
 	-- by _dispatch diffs against state at DRAIN time (see _dispatch's note on
 	-- collapsing chained re-entrant writes).
 	self:_dispatch(function()
-		debug.profilebegin("Dispatch")
 		local rootDiffNode = Diff.diff(oldValue, newValue, nil, nil, ctx, localArrays, boundedMaxDepth)
 		self:_emitRootNode(rootDiffNode, basePath, ancestorSnapshot)
-		debug.profileend()
 	end)
 
 	if arraySink ~= nil and localArrays ~= nil then
@@ -643,8 +638,6 @@ function ChangeDetector._emitRootNode(self: CD_Internal, node: Diff.DiffNode?, b
 	if not node then
 		return
 	end
-	debug.profilebegin("emitRootNode")
-
 	local rootParentPath: PathArray = {}
 	local rootKey: any? = nil
 	if #basePath > 0 then
@@ -660,7 +653,6 @@ function ChangeDetector._emitRootNode(self: CD_Internal, node: Diff.DiffNode?, b
 	-- instead skip their own empty-node work via `ListenerRegistry.HasListenerNodeAt`.
 	self:_processDiffNode(node, basePath, rootParentPath, rootKey, basePath, node, ancestorSnapshot)
 	self:_fireAncestorCallbacks(basePath, node, ancestorSnapshot)
-	debug.profileend()
 end
 
 --[=[
@@ -793,7 +785,6 @@ function ChangeDetector.EmitAncestorNotifications(
 	-- nil = fire every level (unchanged behavior / wildcard registries).
 	levelHasListener: { any }?
 )
-	debug.profilebegin("CD:EmitAncestorNotifications")
 	-- Bound all per-level work to the DEEPEST level that will actually fire. With a
 	-- skip oracle, a deep write observed only by a shallow listener (e.g. a lone
 	-- root `OnChange` under a 10-level path) fires just the top couple of levels —
@@ -814,7 +805,6 @@ function ChangeDetector.EmitAncestorNotifications(
 			end
 		end
 		if topDepth < 0 then
-			debug.profileend()
 			return -- no level fires; nothing to navigate, build, or emit.
 		end
 	end
@@ -900,7 +890,6 @@ function ChangeDetector.EmitAncestorNotifications(
 			end
 		end
 	end
-	debug.profileend()
 end
 
 --[=[

--- a/lib/tablemanager/src/Docs/CONTRACT.md
+++ b/lib/tablemanager/src/Docs/CONTRACT.md
@@ -197,6 +197,17 @@ For a single change, observed order is:
 - `SetPathIgnored(path, ignored)`: an ignored write still updates `Raw`/`Get` but fires nothing and is
   excluded from diffing. `Config.IgnoredPaths` is the construction-time equivalent.
 
+### Reads (`Get` / `GetLastEmitted`)
+- `Get(path, suppressNilPartialPaths?)` returns the current **live** value at `path` (an empty path
+  returns the root / `Raw`). A non-table intermediate segment errors unless `suppressNilPartialPaths`.
+- `GetLastEmitted(path, suppressNilPartialPaths?)` returns the value listeners **last saw** at `path` —
+  the value carried by the most recent change event for `path`, which can lag the live value while a
+  flush is pending (inside a `Batch`/`Suspend` window, or under `FlushMode = "coalesced"` / a deferred
+  fire mode). Under immediate flush with no pending changes it equals `Get`. If `path` was never
+  observed (no baseline was ever recorded), it falls back to a live `Get`. A **table** result is the
+  baseline mirror node and follows the same stability rule as a listener's table `oldValue` (§1.2) —
+  copy it to retain past the synchronous call; scalar results are always safe.
+
 ---
 
 ## 6. Batching

--- a/lib/tablemanager/src/Docs/EXAMPLES.md
+++ b/lib/tablemanager/src/Docs/EXAMPLES.md
@@ -13,8 +13,9 @@ Comprehensive examples for using the TableManager system.
 5. [Parent/Child Relationships](#parentchild-relationships)
 6. [Global Signals](#global-signals)
 7. [Path-Based Access](#path-based-access)
-8. [Common Patterns](#common-patterns)
-9. [Best Practices](#best-practices)
+8. [Opaque Values](#opaque-values)
+9. [Common Patterns](#common-patterns)
+10. [Best Practices](#best-practices)
 
 ---
 
@@ -596,6 +597,61 @@ manager.Proxy.Player.Stats.Mana = 40
 
 > Note: Fusion helper APIs are not part of this package's current public API.
 > Keep integration logic in application code using signals/listeners from this module.
+
+---
+
+## Opaque Values
+
+Marking a value **opaque** tells the diff engine to treat it as an indivisible
+leaf — never cloned, frozen, or walked, only identity-compared. Use it for large
+immutable blobs, foreign objects, or collections of self-contained items. See the
+[Opaque Values guide](/api/TM%20Opaque%20Values) for the full treatment.
+
+### A single opaque leaf
+
+```lua
+local manager = TableManager.new({})
+
+-- Skip the per-diff clone/walk of a big immutable table:
+manager:Set("WorldSnapshot", TableManager.Opaque(hugeReadOnlyTable))
+
+-- Keep a foreign object out of the diff engine entirely:
+manager:Set("Model", TableManager.Opaque(workspace.Rig))
+
+manager:OnValueChange("WorldSnapshot", function()
+    print("snapshot reference replaced")
+end)
+
+manager:Set("WorldSnapshot", nextSnapshot) -- fires once (identity changed)
+-- Mutating hugeReadOnlyTable's internals would fire NOTHING.
+```
+
+### A collection of opaque children
+
+```lua
+local manager = TableManager.new({
+    -- Every direct child of Enemies is a leaf, including ones inserted later.
+    Enemies = TableManager.OpaqueChildren({}),
+})
+
+manager:OnArrayInsert("Enemies", function(index, enemy)
+    print("spawned", enemy.Id)
+end)
+
+-- No per-element wrapping: add/remove still fires, internals stay hidden.
+manager:ArrayInsert("Enemies", { Id = 1, Hp = 100, Ai = {} })
+manager:ArrayInsert("Enemies", { Id = 2, Hp = 100, Ai = {} })
+```
+
+### Shared, read-only reference data
+
+```lua
+local ItemDefs = require(ReplicatedStorage.ItemDefinitions)
+TableManager.GlobalOpaque(ItemDefs) -- mark once; opaque in every manager
+
+local a = TableManager.new({ Defs = ItemDefs })
+local b = TableManager.new({ Cache = { Defs = ItemDefs } })
+```
 
 ---
 

--- a/lib/tablemanager/src/Docs/TM_Flushing.luau
+++ b/lib/tablemanager/src/Docs/TM_Flushing.luau
@@ -104,4 +104,5 @@
 	- **[TM Batching](/api/TM%20Batching)** — deferring flushes to group many writes into one.
 	- **[TM Listeners & Fire Modes](/api/TM%20Listeners%20&%20Fire%20Modes)** — what a flush fires, and how callbacks are scheduled.
 	- **[TM Proxies & Direct Table Access](/api/TM%20Proxies%20&%20Direct%20Table%20Access)** — writing through the manager vs. bypassing it.
+	- **[TM Performance](/api/TM%20Performance)** — the optimizations behind "free when nothing watches" and how to leverage them.
 ]=]

--- a/lib/tablemanager/src/Docs/TM_Getting_Started.luau
+++ b/lib/tablemanager/src/Docs/TM_Getting_Started.luau
@@ -41,11 +41,44 @@
 	manager:Get("Inventory")              -- { "Sword", "Shield" }
 	```
 
+	#### String paths vs. array paths
+
+	Every path-taking method accepts either form, and they resolve to the same
+	place. The choice is not purely cosmetic, though — three things differ:
+
+	- **What keys you can address.** A dot-string is split on `.` into string
+	  segments, so it can *only* reach string keys, and never a key that itself
+	  contains a `.`. An array path holds the keys verbatim, so it is the only way
+	  to address a numeric index, a boolean key, or a string key with a dot in it:
+
+	  ```lua
+	  manager:Get({ "Inventory", 1 })        -- numeric index -> needs an array
+	  manager:Get({ "Config", "a.b.c" })     -- key literally named "a.b.c"
+	  manager:Get("Config.a.b.c")            -- WRONG: reads Config -> a -> b -> c
+	  ```
+
+	- **Type inference / linting.** A *string literal* path lets the type solver
+	  resolve the value's type through the path, so `Get`/`Set` stay type-checked
+	  and autocompleted. An array path (or a string built at runtime) resolves to
+	  `any`, losing that inference. Prefer literal string paths where you want the
+	  types. (Some of this inference is currently disabled pending a Luau bug — see
+	  the tip above.)
+
+	- **Cost.** Passing an array is the cheapest call — it is used as-is. A
+	  dot-string is split once and then **cached**, so a repeated *literal* string
+	  (`"Player.Health"` in a loop) is effectively free after the first use. A
+	  string assembled fresh each call (`"Player." .. field`) never hits that cache
+	  and re-splits every time — for dynamic paths, build an array instead. See the
+	  [Performance](/api/TM%20Performance) guide.
+
+	Rule of thumb: **literal string paths** for readable, type-checked access;
+	**array paths** for dynamic paths and non-string keys.
+
 	### 3. Writing data
 
 	`Set` writes a value at a path; `Update` and `Increment` are convenience
 	wrappers over it. Array contents have their own methods — `ArrayInsert`,
-	`ArrayRemove`, and friends (see the For & Map and Listeners guides).
+	`ArrayRemove`, etc...
 
 	```lua
 	manager:Set("Player.Health", 80)
@@ -140,4 +173,5 @@
 	- **[TM Schema Validation](/api/TM%20Schema%20Validation)** — validating data shape at construction.
 	- **[TM Opaque Values](/api/TM%20Opaque%20Values)** — telling the diff engine to skip certain values.
 	- **[TM For & Map Reactive Views](/api/TM%20For%20&%20Map%20Reactive%20Views)** — per-item reconcilers and derived managers.
+	- **[TM Performance](/api/TM%20Performance)** — the optimizations you get for free and how to leverage them.
 ]=]

--- a/lib/tablemanager/src/Docs/TM_Opaque_Values.luau
+++ b/lib/tablemanager/src/Docs/TM_Opaque_Values.luau
@@ -19,23 +19,94 @@
 	- `GlobalOpaque` / `GlobalOpaqueChildren` — same, but registered in a registry
 	  shared by every manager rather than just this one.
 
-	```lua
-	local manager = TableManager.new({
-		Enemies = TableManager.OpaqueChildren({}), -- each enemy table is a leaf
-	})
+	The wrapper is unwrapped at write time, so what actually lands in the table is
+	the bare inner value — the wrapper only carries the "treat this as opaque"
+	instruction. Marking is by value **reference**, so it survives array shifts,
+	`MoveTo`, and `Swap`. A change to an opaque value's internals fires nothing;
+	replacing the reference fires a single change event at its own slot.
 
-	manager:Set("BigBlob", TableManager.Opaque(hugeImmutableTable))
+	### `Opaque` — one indivisible leaf
+
+	Reach for `Opaque` when a single value should be compared by identity only.
+
+	```lua
+	local manager = TableManager.new({})
+
+	-- A large immutable blob: skip the per-diff clone/walk of thousands of entries.
+	manager:Set("WorldSnapshot", TableManager.Opaque(hugeReadOnlyTable))
+
+	-- A foreign object the diff engine should never traverse.
+	manager:Set("Model", TableManager.Opaque(workspace.Rig))          -- a Roblox Instance
+	manager:Set("Profile", TableManager.Opaque(profileStore.Data))    -- ProfileStore-owned data
+
+	-- Replacing the reference still fires ONE change at "WorldSnapshot";
+	-- mutating the blob's internals fires nothing (identity is unchanged).
+	manager:Set("WorldSnapshot", nextSnapshot)
 	```
 
-	A change to an opaque value's internals fires nothing; replacing the reference
-	fires a single change event at its own slot. Marking is by value reference, so it
-	survives array shifts, `MoveTo`, and `Swap`.
+	### `OpaqueChildren` — a collection of leaves
 
-	:::note Opacity is per-viewer
-	The same live table can be opaque to one manager and transparent to another —
-	e.g. an Inventory manager treats a `Sword` table as an opaque leaf while a
-	dedicated Sword manager observes it transparently. Opacity is also the boundary
-	for implicit cross-manager sharing: an opaque value never propagates.
+	When a container holds many entries that are each individually indivisible,
+	mark the *container* once so every current AND future direct child is opaque —
+	you don't have to wrap each element on insert.
+
+	```lua
+	local manager = TableManager.new({
+		Enemies = TableManager.OpaqueChildren({}),  -- each enemy table is a leaf
+	})
+
+	-- No per-element wrapping needed: later inserts are opaque automatically.
+	manager:ArrayInsert("Enemies", { Id = 1, Hp = 100, Ai = {} })
+	manager:ArrayInsert("Enemies", { Id = 2, Hp = 100, Ai = {} })
+
+	-- The container itself is still diffed: add/remove of an enemy fires
+	-- ArrayInserted/ArrayRemoved. Only each enemy's *internals* are hidden.
+	manager:OnArrayInsert("Enemies", function(index, enemy)
+		print("spawned enemy", enemy.Id)
+	end)
+	```
+
+	### `GlobalOpaque` / `GlobalOpaqueChildren` — shared across every manager
+
+	Use the global variants for reference data that is opaque everywhere, so you
+	mark it once instead of per manager. Ideal for shared, immutable lookup tables.
+
+	```lua
+	local ItemDefs = require(ReplicatedStorage.ItemDefinitions)
+	TableManager.GlobalOpaque(ItemDefs) -- mark once, at startup
+
+	-- Every manager that stores ItemDefs now treats it as an opaque leaf:
+	local a = TableManager.new({ Defs = ItemDefs })
+	local b = TableManager.new({ Cache = { Defs = ItemDefs } })
+	```
+
+	### Per-viewer opacity
+
+	Opacity is a property of *the viewer*, not the value: the same live table can be
+	opaque to one manager and transparent to another. This lets one system hold a
+	coarse view while another observes the detail.
+
+	```lua
+	local sword = { Name = "Sword", Enchant = { Level = 1 } }
+
+	-- The inventory only cares that a sword is present/absent — treat it as a leaf.
+	local inventory = TableManager.new({ Items = TableManager.OpaqueChildren({}) })
+	inventory:ArrayInsert("Items", sword)
+
+	-- A dedicated manager rooted at the SAME table observes its internals fully.
+	local swordManager = TableManager.new(sword)
+	swordManager:OnValueChange("Enchant.Level", function(lvl)
+		print("enchant now", lvl)
+	end)
+
+	swordManager:Set("Enchant.Level", 2) -- swordManager fires; inventory stays silent
+	```
+
+	:::note Opacity is the sharing boundary
+	Opacity is also the boundary for implicit cross-manager sharing: an opaque value
+	never propagates. In the example above, mutating the sword through
+	`swordManager` does not fan out to `inventory`, precisely because `inventory`
+	holds it opaquely.
 	:::
 
 	## Frozen tables
@@ -50,17 +121,39 @@
 	local manager = TableManager.new(data, { FrozenTablesAreOpaque = true })
 	```
 
-	## When to use opacity
+	## How to best leverage opacity
 
-	Reach for opacity when a value is large and immutable (skip the clone/walk cost
-	on every diff), when it's a foreign object the diff engine shouldn't traverse, or
-	when you deliberately want to hide a shared table's internals from one manager
-	while another observes them.
+	Opacity is a performance-and-scoping tool. It pays off most when:
+
+	- **The value is large and immutable.** Skipping the per-diff clone/walk of a
+	  big blob turns an O(n) cost into an O(1) identity compare. Use `Opaque` (or a
+	  deeply frozen table).
+	- **The value is foreign.** Roblox `Instance`s, `ProfileStore` data, userdata, or
+	  any object with custom `__eq`/`__index` should not be traversed by the diff
+	  engine — `Opaque` keeps it out.
+	- **You have a collection of self-contained items.** Mark the container with
+	  `OpaqueChildren` once so every element is a leaf; you still get add/remove
+	  events for the collection, just not spurious "a field deep inside item 37
+	  changed" churn.
+	- **You want to scope observation.** Give a coarse view an opaque handle and a
+	  detailed view a transparent one (the per-viewer pattern above), which also
+	  stops the two from implicitly sharing.
+	- **The data is shared and read-only.** Mark it once with `GlobalOpaque` instead
+	  of per manager.
+
+	When **not** to use it: a value you actually want to observe through this
+	manager. Making it opaque hides exactly the changes you'd otherwise get events
+	for — reach for [Ignored Paths](/api/TableManager#TableManagerConfig) instead if
+	the goal is "don't fire for writes here", or just leave it transparent.
+
+	See the [Performance](/api/TM%20Performance) guide for how opacity fits with the
+	other diff-cost optimizations.
 
 	---
 	### See also
 
 	- **[TM Proxies & Direct Table Access](/api/TM%20Proxies%20&%20Direct%20Table%20Access)** — how reads/writes flow, and duplicate references.
 	- **[TM Flushing](/api/TM%20Flushing)** — the diff cycle opacity opts out of.
+	- **[TM Performance](/api/TM%20Performance)** — opacity alongside the other internal optimizations.
 	- **[TM Schema Validation](/api/TM%20Schema%20Validation)** — the other construction-time data control.
 ]=]

--- a/lib/tablemanager/src/Docs/TM_Performance.luau
+++ b/lib/tablemanager/src/Docs/TM_Performance.luau
@@ -1,0 +1,108 @@
+--[=[
+	@class TM Performance
+
+	[TableManager](/api/TableManager) does a lot of work to turn a raw table
+	mutation into precise, replay-faithful events — but it is built so that work
+	only happens where it earns its keep. This guide explains the optimizations you
+	get **for free** and the handful of habits that let you lean on them, so you can
+	reason about cost instead of guessing.
+
+	The one-line model: TableManager pays for change detection **in proportion to
+	what is actually observed**, not to how much data you store or how often you
+	write it.
+
+	## What you get for free
+
+	### Unobserved writes are (almost) free
+
+	Change detection is a diff, gated by a coverage check. If nothing observes a
+	path — no listener covers it, no global Signal is connected, no linked manager
+	shares it, no `OnApplied` subscriber exists — the whole diff/emit chain is
+	skipped and the write is just a table assignment plus a little bookkeeping.
+
+	```lua
+	local manager = TableManager.new(bigData)
+	manager:Set("Telemetry.Frame", frameId) -- nobody listening here: no diff runs
+	```
+
+	This is why defensive `Flush` calls and writes to "cold" branches stay cheap,
+	and why you don't need to prune listeners you never registered. (See the
+	[Flushing](/api/TM%20Flushing) guide — a flush is a no-op when nothing watches.)
+
+	### Diffs stop at the deepest listener
+
+	When a path *is* observed, the diff is still **depth-bounded**: it descends only
+	as deep as the deepest listener that could fire. A listener at `Player` does not
+	force a walk of every leaf under `Player` — only down to the levels something
+	actually watches.
+
+	### Big or foreign values can opt out entirely
+
+	A value marked **opaque** (or a deeply frozen table) is compared by identity
+	only — never cloned, frozen, or walked. This turns the per-diff cost of a large
+	immutable blob or a foreign object from O(n) into O(1). See the
+	[Opaque Values](/api/TM%20Opaque%20Values) guide.
+
+	### Shared baseline, patched in place
+
+	The "last emitted" baseline every diff compares against is a **shared,
+	identity-keyed** store: managers that co-observe the same live table share one
+	baseline instead of each keeping a copy. And common writes patch that baseline
+	incrementally — a scalar field set or a single array insert/remove updates the
+	baseline spine directly rather than re-copying the surrounding subtree.
+
+	### Hot write paths avoid redundant work
+
+	- A plain non-nil `Set` (no dynamic table-building) resolves the parent chain
+	  **once**, not twice.
+	- `Update`, `Increment`, `UpdateKey`, and `IncrementKey` are single-walk
+	  read-modify-writes — they don't re-navigate the path between the read and the
+	  write.
+	- A scalar-to-scalar `Set` in immediate mode takes a fast lane that synthesizes
+	  its one-node diff directly, skipping the general diff engine.
+
+	### Many changes can collapse into one flush
+
+	Both explicit [batching](/api/TM%20Batching) and `FlushMode = "coalesced"`
+	merge many writes into a single diff/fire. Repeated fires of the *same* Signal
+	within a tick can also coalesce into one. N writes under a subtree then cost one
+	flush, not N.
+
+	## How to leverage it
+
+	A short checklist, most-impactful first:
+
+	1. **Write through the API.** `Set`/`ArrayInsert`/the proxy are what let the
+	   coverage gate and incremental baseline patching kick in. Bypassing them and
+	   later calling `Flush` forces a full re-diff of the branch.
+	2. **Don't over-subscribe.** Register listeners at the shallowest path and depth
+	   that meets your need; every extra deep listener widens the diff bound. Prefer
+	   one `OnChange` at a subtree over many leaf listeners when you only need "did
+	   anything here change".
+	3. **Batch bulk edits.** Wrap loops of writes in `Batch` (or use `coalesced`
+	   flush for high-frequency, frame-driven updates) so listeners fire once.
+	4. **Mark big/foreign values opaque.** Anything large-and-immutable or
+	   foreign-and-un-walkable should be `Opaque` / `GlobalOpaque`.
+	5. **Ignore paths you never observe but write hot.** `IgnoredPaths` (or
+	   `SetPathIgnored`) skips all diff/event work for a branch while keeping the
+	   value live in `Raw`/`Get`.
+	6. **Reuse literal string paths; use arrays for dynamic ones.** A repeated
+	   *literal* string path is parsed once and cached; a string assembled per call
+	   (`"Player." .. field`) re-splits every time — pass an array for those. See
+	   the string-vs-array notes in [Getting Started](/api/TM%20Getting%20Started).
+
+	:::tip Measure, don't assume
+	These optimizations mean the expensive cases are the observable, deep, large
+	ones. If a workload feels slow, look first at *what is being observed* (listener
+	breadth/depth) and *what is being walked* (large transparent tables), not at the
+	raw write count.
+	:::
+
+	---
+	### See also
+
+	- **[TM Flushing](/api/TM%20Flushing)** — the diff→fire→reconcile cycle and the "free when nothing watches" rule.
+	- **[TM Batching](/api/TM%20Batching)** — collapsing many writes into one flush.
+	- **[TM Opaque Values](/api/TM%20Opaque%20Values)** — opting large/foreign values out of the diff.
+	- **[TM Getting Started](/api/TM%20Getting%20Started)** — string vs. array paths and the path cache.
+]=]

--- a/lib/tablemanager/src/Docs/TM_Reactive_State_Wrappers.luau
+++ b/lib/tablemanager/src/Docs/TM_Reactive_State_Wrappers.luau
@@ -96,9 +96,7 @@
 		local connection = manager:OnChange(path, function(newValue)
 			src(newValue)
 		end, options)
-		cleanup(function()
-			connection:Disconnect()
-		end)
+		cleanup(connection)
 		return src
 	end
 
@@ -115,22 +113,6 @@
 	do nothing — `scope:doCleanup()` (Fusion) or the reactive scope's destruction
 	(Vide) disconnects the binding. Destroying the manager
 	([`manager:Destroy()`](/api/TableManager#Destroy)) also disconnects everything.
-
-	## Two-way binding
-
-	These wrappers are one-way (data → view), which is the common UI case. To push
-	edits *back* into the manager, drive `manager:Set` from the framework's own
-	observer — and guard the feedback loop so a manager-originated update doesn't
-	bounce back as a redundant write:
-
-	```lua
-	Fusion.Observer(state):onChange(function()
-		local next = Fusion.peek(state)
-		if next ~= manager:Get(path) then -- only write real changes
-			manager:Set(path, next)
-		end
-	end)
-	```
 
 	---
 	### See also

--- a/lib/tablemanager/src/Listening/Emitter.luau
+++ b/lib/tablemanager/src/Listening/Emitter.luau
@@ -254,7 +254,6 @@ function Emitter.fireAncestorValueChangedNotifications(
 	metadata: ChangeMetadata,
 	includeKeyChanged: boolean?
 )
-	debug.profilebegin("fireAncestorValueChangedNotifications")
 	const ancestorMetadata: ChangeMetadata = {
 		Diff = nil,
 		OriginPath = metadata.OriginPath,
@@ -293,7 +292,6 @@ function Emitter.fireAncestorValueChangedNotifications(
 	)
 
 	registry:EndAncestorSpine()
-	debug.profileend()
 end
 
 --[[
@@ -385,7 +383,6 @@ function Emitter.emitRemoved(
 	move: MoveMetadata?,
 	knownTrackable: boolean?
 )
-	debug.profilebegin("emitRemoved")
 	const removedPath: PathArray = PathHelpers.Append(path, index)
 	-- Array element old values are never a slice of some larger captured
 	-- container (unlike the dict path's diff `old`, each direct array op
@@ -401,7 +398,6 @@ function Emitter.emitRemoved(
 		OldValue = oldValue,
 		Metadata = metadata,
 	}, knownTrackable)
-	debug.profileend()
 end
 
 function Emitter.emitInserted(
@@ -412,7 +408,6 @@ function Emitter.emitInserted(
 	move: MoveMetadata?,
 	knownTrackable: boolean?
 )
-	debug.profilebegin("emitInserted")
 	const insertedPath = PathHelpers.Append(path, index)
 	const metadata = createSyntheticMetadata(manager.Raw, insertedPath, "added", index, newValue, nil, nil)
 	metadata.Move = move
@@ -421,7 +416,6 @@ function Emitter.emitInserted(
 		NewValue = newValue,
 		Metadata = metadata,
 	}, knownTrackable)
-	debug.profileend()
 end
 
 function Emitter.emitSet(
@@ -433,7 +427,6 @@ function Emitter.emitSet(
 	move: MoveMetadata?,
 	knownTrackable: boolean?
 )
-	debug.profilebegin("emitSet")
 	const setPath = PathHelpers.Append(path, index)
 	const oldSnapshot = BatchUtilsModule.BuildOldSnapshotForLeaf(manager, path, setPath, oldValue)
 	const metadata = createSyntheticMetadata(manager.Raw, setPath, "changed", index, newValue, oldValue, oldSnapshot)
@@ -444,7 +437,6 @@ function Emitter.emitSet(
 		OldValue = oldValue,
 		Metadata = metadata,
 	}, knownTrackable)
-	debug.profileend()
 end
 
 --[[

--- a/lib/tablemanager/src/Mutator.luau
+++ b/lib/tablemanager/src/Mutator.luau
@@ -394,7 +394,6 @@ function Mutator.applyWrite<T, S>(self: TM_Internal<T>, parsedPath: PathArray<S>
 	end
 
 	if self._batchDepth > 0 then
-		debug.profilebegin("applyWrite (batched)")
 		const batch = self._batch
 		const parentPath: PathArray<S> = table.move(parsedPath, 1, lastIdx - 1, 1, table.create(lastIdx - 1)) :: any
 		-- Only the batched path needs the full O(n) classification: it gates
@@ -417,11 +416,9 @@ function Mutator.applyWrite<T, S>(self: TM_Internal<T>, parsedPath: PathArray<S>
 			PropagationModule.RegisterSubtree(self, newValue)
 		end
 		Mutator.pruneDetachedValue(self, oldValue, newValue)
-		debug.profileend()
 		return
 	end
 
-	debug.profilebegin("applyWrite (immediate)")
 	const oldValue = parentTable[key]
 	-- Trackability and the diff depth bound resolve together in one registry
 	-- walk + one signal probe (`ResolveWriteObservation`); the depth is handed
@@ -470,10 +467,8 @@ function Mutator.applyWrite<T, S>(self: TM_Internal<T>, parsedPath: PathArray<S>
 			-- never-materialized slot.
 			BaselineModule.SeedIfNeeded(self, parsedPath, oldValue)
 			parentTable[key] = newValue
-			debug.profileend()
 			return
 		end
-		debug.profilebegin("applyWrite (scalar fast lane)")
 		parentTable[key] = newValue
 		-- RegisterSubtree and pruneDetachedValue are both no-ops for scalar
 		-- old/new values — deliberately skipped.
@@ -486,8 +481,6 @@ function Mutator.applyWrite<T, S>(self: TM_Internal<T>, parsedPath: PathArray<S>
 			else { type = "changed" :: "changed", old = oldValue, new = newValue, children = nil }
 		const oldSnapshot = BatchUtilsModule.BuildOldSnapshot(self, parsedPath, oldValue)
 		self._changeDetector:DispatchDiffNode(diffNode, parsedPath :: { any }, self.Raw :: any, oldSnapshot)
-		debug.profileend()
-		debug.profileend()
 		return
 	end
 
@@ -514,7 +507,6 @@ function Mutator.applyWrite<T, S>(self: TM_Internal<T>, parsedPath: PathArray<S>
 		-- subscriber still needs to see it -- ship the value directly.
 		EmitterModule.emitReplicationOp(self, "Set", parsedPath, newValue, nil, nil)
 	end
-	debug.profileend()
 end
 
 --[[

--- a/lib/tablemanager/src/Propagation.luau
+++ b/lib/tablemanager/src/Propagation.luau
@@ -154,7 +154,6 @@ const function registerSubtree(manager: TableManagerLike, value: any)
 	if type(value) ~= "table" then
 		return
 	end
-	debug.profilebegin("registerSubtree")
 	const ctx = manager._changeDetector:GetOpaqueCtx()
 	const isOpaque = ctx ~= nil and ctx.isOpaque
 	const registries = manager._opaqueRegistries
@@ -204,7 +203,6 @@ const function registerSubtree(manager: TableManagerLike, value: any)
 		end
 	end
 	recurse(value)
-	debug.profileend()
 end
 
 --------------------------------------------------------------------------------

--- a/lib/tablemanager/src/TableManager.luau
+++ b/lib/tablemanager/src/TableManager.luau
@@ -26,25 +26,32 @@
 
 	
 	### Usage
-	
+
 	```lua
-	const manager = TableManager.new({
-		player = { health = 100, level = 5 },
-		settings = { volume = 80 }
+	local manager = TableManager.new({
+		Player = { Name = "Alice", Health = 100 },
+		Inventory = { "Sword", "Shield" },
 	})
-	
-	-- Listen to direct changes only
-	manager:OnChange("player", function(newValue, oldValue, metadata)
 
+	-- Fire when a specific field changes.
+	manager:OnValueChange("Player.Health", function(health, oldHealth)
+		print(`health: {oldHealth} -> {health}`)
 	end)
-	
-	-- Listen to all changes (including descendants)
-	manager:OnValueChange("player", function(newValue, oldValue, metadata)
 
+	-- Fire for any change under a subtree (the field OR a descendant).
+	manager:OnChange("Player", function(_, _, metadata)
+		print("player changed at:", table.concat(metadata.OriginPath, "."))
 	end)
-	
-	-- Array operations
-	manager:ArrayInsert("player.items", "Sword")
+
+	manager:Set("Player.Health", 80)
+	-- prints "health: 100 -> 80"
+	--        "player changed at: Player.Health"
+
+	-- Array contents have their own methods and events.
+	manager:OnArrayInsert("Inventory", function(index, item)
+		print(`picked up {item} (slot {index})`)
+	end)
+	manager:ArrayInsert("Inventory", "Potion") -- prints "picked up Potion (slot 3)"
 	```
 
 	## Best Practices
@@ -562,20 +569,16 @@ end
 	```
 ]=]
 function TableManager.GetMatching<T, S>(self: TM_Internal<T>, path: Path<S>): { PathHelpers.WildcardExpansion }
-	debug.profilebegin("TM.GetMatching")
 	const parsedPath = PathHelpers.ParsePath(path)
 	const wildcardIndex = PathHelpers.FindFirstWildcard(parsedPath)
 	if wildcardIndex == nil then
-		debug.profileend()
 		const value = self:Get(parsedPath :: any)
 		if value == nil then
 			return {}
 		end
 		return { { Path = table.clone(parsedPath), Value = value, WildcardMatches = nil } }
 	end
-	const entries = resolveWildcardExpansion(self, parsedPath, wildcardIndex, false)
-	debug.profileend()
-	return entries
+	return resolveWildcardExpansion(self, parsedPath, wildcardIndex, false)
 end
 
 --[=[
@@ -600,7 +603,6 @@ function TableManager.GetProxy<T, S>(
 	path: Path<S>,
 	suppressNilPartialPaths: boolean?
 ): (Proxy<T, S> | ValueAtPath<T, S>)?
-	debug.profilebegin("TableManager.GetProxy")
 	const proxyManager = self._proxyManager
 	if proxyManager == nil then
 		error("GetProxy requires proxies (Config.EnableProxies = false for this TableManager)")
@@ -610,7 +612,6 @@ function TableManager.GetProxy<T, S>(
 	local previousKey: any = nil
 	for _, key in parsedPath do
 		if not proxyManager:IsProxy(current) then
-			debug.profileend()
 			if suppressNilPartialPaths then
 				return nil
 			else
@@ -620,8 +621,64 @@ function TableManager.GetProxy<T, S>(
 		current = current[key]
 		previousKey = key
 	end
-	debug.profileend()
 	return current
+end
+
+--[=[
+	@within TableManager
+	@method GetLastEmitted
+
+	Reads the value at `path` as listeners **last saw it** -- the value carried by
+	the most recent change event fired for `path`, rather than the current live
+	value. Under the default immediate flush mode with no pending changes this is
+	identical to [TableManager:Get]; the two diverge only when the live data has
+	moved ahead of what has been emitted -- inside a `Batch`/`Suspend` window, or
+	under `FlushMode = "coalesced"` / a deferred fire mode, before the pending
+	flush runs.
+
+	If `path` has never been observed (no listener, Signal, link, or `OnApplied`
+	subscriber ever covered it) there is no recorded "last emitted" value, so this
+	falls back to a live [TableManager:Get] -- the same value a first listener
+	would receive.
+
+	:::caution Table results are snapshots
+	When the value at `path` is a table, the returned table is the internal
+	baseline mirror of the last-emitted state: it follows the same stability rules
+	as a listener's table `oldValue` (a stable snapshot only for the duration of
+	the synchronous call -- copy it if you need to retain it). Scalar results are
+	always safe to keep.
+	:::
+
+	@param path Path
+	@param suppressNilPartialPaths boolean? -- Return `nil` instead of erroring when a segment along the path is not a table (only consulted on the live fallback).
+	@return any -- The value last emitted for `path` (or the live value when `path` was never observed).
+
+	```lua
+	local manager = TableManager.new({ Score = 0 }, { FlushMode = "coalesced" })
+	manager:OnValueChange("Score", function() end) -- observe so a baseline is kept
+
+	manager:Set("Score", 10)
+	manager:Get("Score")            -- 10 (live)
+	manager:GetLastEmitted("Score") -- 0  (listeners have not been told yet)
+
+	manager:Flush("Score")
+	manager:GetLastEmitted("Score") -- 10 (now emitted)
+	```
+]=]
+function TableManager.GetLastEmitted<T, S>(
+	self: TM_Internal<T>,
+	path: Path<S>,
+	suppressNilPartialPaths: boolean?
+): ValueAtPath<T, S>?
+	const parsedPath = PathHelpers.ParsePath(path)
+	const baseline = BaselineModule.Get(self, parsedPath)
+	if baseline ~= nil then
+		return baseline
+	end
+	-- No materialized baseline (path never observed, or its last-emitted value is
+	-- itself nil): fall back to the current live value -- what a first listener
+	-- would see.
+	return self:Get(parsedPath :: any, suppressNilPartialPaths)
 end
 
 --[=[
@@ -879,7 +936,6 @@ end
 	```
 ]=]
 function TableManager.ArrayInsert<T, S>(self: TM_Internal<T>, pathOrProxy: Path<S> | Proxy<T, S>, ...: any): ()
-	debug.profilebegin("TM.ArrayInsert")
 	local parsedPath, array = resolveArrayForWrite(self, pathOrProxy)
 
 	-- Determine if a position was provided or default to appending.
@@ -924,7 +980,6 @@ function TableManager.ArrayInsert<T, S>(self: TM_Internal<T>, pathOrProxy: Path<
 			EmitterModule.emitReplicationOp(self, "ArrayInsert", parsedPath, unwrappedValue, pos, nil)
 		end
 	end
-	debug.profileend()
 end
 TableManager.Insert = TableManager.ArrayInsert
 
@@ -943,7 +998,6 @@ TableManager.Insert = TableManager.ArrayInsert
 	@return any -- The removed element.
 ]=]
 function TableManager.ArrayRemove<T, S>(self: TM_Internal<T>, pathOrProxy: Path<S> | Proxy<T, S>, index: number): any
-	debug.profilebegin("TM.ArrayRemove")
 	local parsedPath, array = resolveArrayForWrite(self, pathOrProxy)
 
 	const inBatch = trackArrayMutation(self, parsedPath)
@@ -957,7 +1011,6 @@ function TableManager.ArrayRemove<T, S>(self: TM_Internal<T>, pathOrProxy: Path<
 	pruneDetachedValue(self, oldValue, nil)
 
 	if inBatch then
-		debug.profileend()
 		return oldValue
 	end
 
@@ -969,7 +1022,6 @@ function TableManager.ArrayRemove<T, S>(self: TM_Internal<T>, pathOrProxy: Path<
 	elseif self._appliedListeners[1] ~= nil then
 		EmitterModule.emitReplicationOp(self, "ArrayRemove", parsedPath, nil, index, nil)
 	end
-	debug.profileend()
 	return oldValue
 end
 TableManager.Remove = TableManager.ArrayRemove
@@ -1305,7 +1357,6 @@ function TableManager.MoveTo<T, S1, S2>(
 	currentPath: Path<S1> | Proxy<T, S1>,
 	newPath: Path<S2> | Proxy<T, S2>
 )
-	debug.profilebegin("TM.MoveTo")
 	const sourcePath: PathArray<S1> = resolvePathFromPathOrProxy(self, currentPath)
 	const targetPath: PathArray<S2> = resolvePathFromPathOrProxy(self, newPath)
 
@@ -1314,7 +1365,6 @@ function TableManager.MoveTo<T, S1, S2>(
 	end
 
 	if PathHelpers.ArePathsEqual(sourcePath, targetPath) then
-		debug.profileend()
 		return
 	end
 
@@ -1343,7 +1393,6 @@ function TableManager.MoveTo<T, S1, S2>(
 		restoreReparent(self._proxyManager, rollback)
 		error(moveErr, 2)
 	end
-	debug.profileend()
 end
 
 --[=[
@@ -1357,7 +1406,6 @@ end
 	This is specifically useful for copying tables around without breaking proxy references.
 ]=]
 function TableManager.CopyTo<T, S1, S2>(self: TM_Internal<T>, currentPath: Path<S1> | Proxy<T, S1>, newPath: Path<S2>)
-	debug.profilebegin("TM.CopyTo")
 	const sourcePath = resolvePathFromPathOrProxy(self, currentPath)
 	const targetPath = resolvePathFromPathOrProxy(self, newPath)
 
@@ -1377,7 +1425,6 @@ function TableManager.CopyTo<T, S1, S2>(self: TM_Internal<T>, currentPath: Path<
 	const sourceValue = self:Get(sourcePath)
 	const copiedValue = deepCloneValue(sourceValue)
 	self:Set(targetPath, copiedValue)
-	debug.profileend()
 end
 
 --[=[

--- a/lib/tablemanager/src/Tests/TM/TableManager.get-last-emitted.spec.luau
+++ b/lib/tablemanager/src/Tests/TM/TableManager.get-last-emitted.spec.luau
@@ -1,0 +1,111 @@
+--!strict
+--[[
+	Specs for `TableManager:GetLastEmitted(path)` (CONTRACT.md §5 "Reads").
+
+	`GetLastEmitted` returns the value listeners LAST SAW at `path` — the internal
+	"last-emitted" baseline — which lags the live `Get` value while a flush is
+	pending (a `Suspend`/`Batch` window, or `FlushMode = "coalesced"`). Under
+	immediate flush with no pending changes it equals `Get`, and for a path that was
+	never observed (no baseline recorded) it falls back to a live `Get`.
+]]
+
+return function(tiniest)
+	local TableManager = require("../../TableManager")
+
+	local describe = tiniest.describe
+	local test = tiniest.test
+	local expect = tiniest.expect
+
+	describe("GetLastEmitted", function()
+		test("equals Get under immediate flush with no pending changes", function()
+			local manager = TableManager.new({ player = { health = 100 } })
+			manager:OnValueChange("player.health", function() end)
+
+			expect(manager:GetLastEmitted("player.health")).is(manager:Get("player.health"))
+
+			manager:Set("player.health", 60)
+			-- Immediate flush already emitted 60, so both agree.
+			expect(manager:Get("player.health")).is(60)
+			expect(manager:GetLastEmitted("player.health")).is(60)
+
+			manager:Destroy()
+		end)
+
+		test("falls back to the live value for a never-observed path", function()
+			local manager = TableManager.new({ coins = 0 })
+			-- No listener/signal covers "coins": no baseline is ever recorded.
+			manager:Set("coins", 42)
+
+			-- Falls back to a live Get rather than returning nil.
+			expect(manager:GetLastEmitted("coins")).is(42)
+			expect(manager:GetLastEmitted("coins")).is(manager:Get("coins"))
+
+			manager:Destroy()
+		end)
+
+		test("lags the live value while a coalesced flush is pending, then converges", function()
+			local manager = TableManager.new({ Score = 0 }, { FlushMode = "coalesced" })
+			-- Observe so a baseline is kept for "Score".
+			manager:OnValueChange("Score", function() end)
+
+			manager:Set("Score", 10) -- schedules a frame-end flush; not drained yet
+
+			-- Live value moved ahead; listeners have not been told yet.
+			expect(manager:Get("Score")).is(10)
+			expect(manager:GetLastEmitted("Score")).is(0)
+
+			task.wait() -- let the deferred flush run
+
+			expect(manager:GetLastEmitted("Score")).is(10)
+			expect(manager:GetLastEmitted("Score")).is(manager:Get("Score"))
+
+			manager:Destroy()
+		end)
+
+		test("holds the pre-batch value inside a Suspend window, then converges on Resume", function()
+			local manager = TableManager.new({ x = 0 })
+			manager:OnValueChange("x", function() end)
+
+			-- Establish the baseline via an immediate write (emits 1).
+			manager:Set("x", 1)
+			expect(manager:GetLastEmitted("x")).is(1)
+
+			manager:Suspend()
+			manager:Set("x", 2) -- batched: nothing emitted yet
+
+			expect(manager:Get("x")).is(2)          -- live
+			expect(manager:GetLastEmitted("x")).is(1) -- last emitted
+
+			manager:Resume()
+
+			expect(manager:GetLastEmitted("x")).is(2)
+			expect(manager:GetLastEmitted("x")).is(manager:Get("x"))
+
+			manager:Destroy()
+		end)
+
+		test("returns nil once an observed path's last-emitted value is a deletion", function()
+			local manager = TableManager.new({ buff = "speed" })
+			manager:OnValueChange("buff", function() end)
+
+			manager:Set("buff", nil) -- emitted removal
+
+			expect(manager:GetLastEmitted("buff")).never_exists()
+			expect(manager:Get("buff")).never_exists()
+
+			manager:Destroy()
+		end)
+
+		test("accepts array paths equivalently to string paths", function()
+			local manager = TableManager.new({ player = { mana = 30 } })
+			manager:OnValueChange("player.mana", function() end)
+
+			manager:Set("player.mana", 15)
+
+			expect(manager:GetLastEmitted({ "player", "mana" })).is(15)
+			expect(manager:GetLastEmitted({ "player", "mana" })).is(manager:GetLastEmitted("player.mana"))
+
+			manager:Destroy()
+		end)
+	end)
+end

--- a/moonwave.toml
+++ b/moonwave.toml
@@ -31,6 +31,7 @@ classes = [
 	"TM Proxies & Direct Table Access",
 	"TM Schema Validation",
 	"TM Opaque Values",
+	"TM Performance",
 	"TM Reactive State Wrappers",
 	"TM For & Map Views [Unreleased]",
 ]


### PR DESCRIPTION
This pull request primarily removes debug profiling calls from the core diffing engine for cleaner production code, and significantly expands documentation on opaque values, path handling, and performance optimization in the TableManager system. The documentation changes clarify usage patterns, best practices, and the impact of various features on performance and system behavior.

**Key changes:**

### Codebase cleanup

- Removed all `debug.profilebegin` and `debug.profileend` calls from the main diffing and notification methods in `ChangeDetector` to reduce overhead and noise in production environments. [[1]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L307-L308) [[2]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L326) [[3]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L440-L443) [[4]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L646-L647) [[5]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L663) [[6]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L796) [[7]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L817) [[8]](diffhunk://#diff-ac3573ba58762ceb365b4fc750e21f60fd3df91369deae935a7718422d938ca3L903)

### Documentation improvements: Opaque values

- Greatly expanded the "Opaque Values" documentation and examples, including new sections in both the API guide and examples file. These changes clarify how and when to use `Opaque`, `OpaqueChildren`, and their global variants, with detailed explanations, code samples, and guidance on per-viewer opacity and performance implications. [[1]](diffhunk://#diff-5b26d4fb6a7d72989bec2e67d479ec8fb0ed37ccf450bac9eaf4fe47ed563250R603-R657) [[2]](diffhunk://#diff-72f4eb3b5f35a97cf22c215d657c52101a55a06cb93f7c302a707b12aa25494dR22-R109) [[3]](diffhunk://#diff-72f4eb3b5f35a97cf22c215d657c52101a55a06cb93f7c302a707b12aa25494dL53-R157)

### Documentation improvements: Path handling and performance

- Added a new section to the Getting Started guide explaining the differences between string and array paths, their impact on key addressing, type inference, and performance, along with best practices for each.
- Updated reference links throughout the documentation to point to the new "Performance" guide, ensuring users can easily find information on optimizing TableManager usage. [[1]](diffhunk://#diff-b9ee52abe1bc059b52eda83ae628827ac54c765ad4fa70e048d33f7be7040535R176) [[2]](diffhunk://#diff-f141f3e4a7fe728bc9c4173999eeac763ac637c0835f9b2155d30e5ba528ae80R107)

### Documentation improvements: API reference

- Added detailed documentation for the `Get` and `GetLastEmitted` read methods, clarifying their semantics and use cases.

### Documentation structure

- Updated the main examples index to include the new "Opaque Values" section and adjusted numbering for subsequent sections.

These changes make the TableManager system more approachable, better documented, and easier to use efficiently in production.