### PR TITLE
Add UIParticleEmitter package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ModulesOnRails is a collection of Wally packages to streamline Roblox developmen
 | [T](https://raild3x.github.io/ModulesOnRails/api/T) | `T = "raild3x/t@1.1.0"` | A runtime typechecker for Luau/Roblox |
 | [TableManager](https://raild3x.github.io/ModulesOnRails/api/TableManager) | `TableManager = "raild3x/tablemanager@1.0.2"` | A Luau library for managing tables. |
 | [TableReplicator](https://raild3x.github.io/ModulesOnRails/api/TableReplicator) | `TableReplicator = "raild3x/tablereplicator@1.0.1"` | Replicates a TableManager instance from server to client with minimal effort. |
-| [UIParticleEmitter](https://raild3x.github.io/ModulesOnRails/api/UIParticleEmitter) | `UIParticleEmitter = "raild3x/uiparticleemitter@0.1.0"` | FusionComponent for emitting 2d images |
+| [UIParticleEmitter](https://raild3x.github.io/ModulesOnRails/api/UIParticleEmitter) | `UIParticleEmitter = "raild3x/uiparticleemitter@0.1.0"` | FusionComponent for emitting 2D images |
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ModulesOnRails is a collection of Wally packages to streamline Roblox developmen
 | [T](https://raild3x.github.io/ModulesOnRails/api/T) | `T = "raild3x/t@1.1.0"` | A runtime typechecker for Luau/Roblox |
 | [TableManager](https://raild3x.github.io/ModulesOnRails/api/TableManager) | `TableManager = "raild3x/tablemanager@1.0.2"` | A Luau library for managing tables. |
 | [TableReplicator](https://raild3x.github.io/ModulesOnRails/api/TableReplicator) | `TableReplicator = "raild3x/tablereplicator@1.0.1"` | Replicates a TableManager instance from server to client with minimal effort. |
+| [UIParticleEmitter](https://raild3x.github.io/ModulesOnRails/api/UIParticleEmitter) | `UIParticleEmitter = "raild3x/uiparticleemitter@0.1.0"` | FusionComponent for emitting 2d images |
 
 
 ---

--- a/lib/uiparticleemitter/src/Emitter.luau
+++ b/lib/uiparticleemitter/src/Emitter.luau
@@ -1,0 +1,471 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	The UIParticleEmitter Fusion component. Owns the spawn-area frame, the
+	per-emitter particles folder, the particle list/pool, and the update loop.
+
+	Lifecycle:
+	- The update loop runs only while there are live particles or the emitter
+	  is Enabled; it disconnects itself when idle.
+	- On scope/UI destruction the emitter stops spawning, but by design live
+	  particles finish their natural lifetime first: the update connection
+	  deliberately survives the Fusion scope and disconnects itself once the
+	  last particle dies (the "draining" phase). Set the
+	  `CleanupParticlesImmediately` prop to true to destroy live particles
+	  the moment the emitter is destroyed instead.
+]]
+
+--// Roblox Services //--
+local RunService = game:GetService("RunService")
+
+--// Imports //--
+local Fusion = require("../Fusion")
+local ParticlePool = require("./ParticlePool")
+local PropResolver = require("./PropResolver")
+local SequenceUtil = require("./SequenceUtil")
+local Simulation = require("./Simulation")
+local Types = require("./Types")
+
+local peek = Fusion.peek
+local Parse = PropResolver.Parse
+local Defaults = PropResolver.Defaults
+
+-- RenderStepped only exists on clients; fall back to Heartbeat so the
+-- emitter still works (and is testable) in plugin/server contexts.
+local STEP_SIGNAL: RBXScriptSignal = if RunService:IsClient() then RunService.RenderStepped else RunService.Heartbeat
+
+local PARTICLES_FOLDER_NAME = "UIParticles"
+
+local Emitter = {}
+Emitter.__index = Emitter
+
+--------------------------------------------------------------------------------
+-- Internal helpers
+--------------------------------------------------------------------------------
+
+local function resolveUDim2(value: UDim2, containerSize: Vector2): (number, number)
+	return value.X.Scale * containerSize.X + value.X.Offset, value.Y.Scale * containerSize.Y + value.Y.Offset
+end
+
+-- Computes the absolute spawn rectangle. Fire() overrides win over the UI
+-- frame's own geometry.
+local function computeSpawnArea(
+	ui: Frame,
+	layerCollector: LayerCollector,
+	area: Types.SpawnAreaOverrides?
+): (Vector2, Vector2)
+	local hasOverride = area
+		and (
+			area.SpawnAreaPosition
+			or area.SpawnAreaAbsolutePosition
+			or area.SpawnAreaAnchorPoint
+			or area.SpawnAreaSize
+		)
+	if not hasOverride then
+		return ui.AbsolutePosition, ui.AbsoluteSize
+	end
+	assert(area, "unreachable")
+
+	local layerCollectorSize = layerCollector.AbsoluteSize
+
+	local sizeX, sizeY = resolveUDim2(area.SpawnAreaSize or ui.Size, layerCollectorSize)
+	local containerSize = Vector2.new(sizeX, sizeY)
+
+	local posX: number, posY: number
+	if area.SpawnAreaAbsolutePosition then
+		posX = area.SpawnAreaAbsolutePosition.X
+		posY = area.SpawnAreaAbsolutePosition.Y
+	else
+		posX, posY = resolveUDim2(area.SpawnAreaPosition or ui.Position, layerCollectorSize)
+	end
+
+	local anchor = area.SpawnAreaAnchorPoint or ui.AnchorPoint
+	local containerPos = Vector2.new(posX - anchor.X * containerSize.X, posY - anchor.Y * containerSize.Y)
+
+	return containerPos, containerSize
+end
+
+--------------------------------------------------------------------------------
+-- Constructor
+--------------------------------------------------------------------------------
+
+function Emitter.new(scope: Types.Scope<any>, props: Types.EmitterProps)
+	local self = setmetatable({}, Emitter)
+
+	self._props = props
+	self._particles = {} :: { Types.Particle }
+	self._rng = if props.Seed then Random.new(props.Seed) else Random.new()
+	self._pool = ParticlePool.new(function()
+		return peek(props.MaxParticles) or Defaults.MaxParticles
+	end)
+	self._timeSinceLastSpawn = 0
+	self._lastInset = 0
+	self._connection = nil :: RBXScriptConnection?
+	self._folder = nil :: Folder?
+	self._destroyed = false -- destruction initiated (no more spawning)
+	self._dead = false -- destruction finished (folder gone, loop stopped)
+	self._warnedNoTarget = false
+
+	self.UI = Fusion.New(scope, "Frame") {
+		Name = "UIParticleEmitter",
+		Parent = props.Parent,
+		Position = props.SpawnAreaPosition or UDim2.fromScale(0.5, 0.5),
+		AnchorPoint = props.SpawnAreaAnchorPoint or Vector2.new(0.5, 0.5),
+		Size = props.SpawnAreaSize or UDim2.fromScale(0, 0),
+		BackgroundTransparency = 1,
+		ZIndex = 10,
+	} :: Frame
+
+	self.UI.Destroying:Connect(function()
+		self:_OnDestroyed()
+	end)
+	table.insert(scope, function()
+		self:_OnDestroyed()
+	end)
+
+	-- Enabled may be a constant or a state object; Observer only accepts
+	-- state objects, so constants are handled with a one-time check.
+	const function onEnabledChanged()
+		if peek(props.Enabled) and not self._destroyed then
+			self._timeSinceLastSpawn = 0
+			self:_EnsureRunning()
+		end
+	end
+	if typeof(props.Enabled) == "table" then
+		Fusion.Observer(scope, props.Enabled :: any):onBind(onEnabledChanged)
+	else
+		onEnabledChanged()
+	end
+
+	if typeof(props.Visible) == "table" then
+		Fusion.Observer(scope, props.Visible :: any):onChange(function()
+			local visible = peek(props.Visible) ~= false
+			for _, particle in self._particles do
+				particle.Instance.Visible = visible
+			end
+		end)
+	end
+
+	return self
+end
+
+--------------------------------------------------------------------------------
+-- Update loop
+--------------------------------------------------------------------------------
+
+function Emitter:_EnsureRunning()
+	if self._connection or self._dead then
+		return
+	end
+	self._connection = STEP_SIGNAL:Connect(function(dt: number)
+		self:_Step(dt)
+	end)
+end
+
+function Emitter:_Disconnect()
+	if self._connection then
+		self._connection:Disconnect()
+		self._connection = nil
+	end
+end
+
+--[[
+	Advances the emitter by `dt` seconds: simulates and renders every live
+	particle, reclaims dead ones, spawns new ones while Enabled, and manages
+	the loop/drain lifecycle. Public behavior is driven by the step signal;
+	specs may call this directly (after :Stop()) to simulate time.
+]]
+function Emitter:_Step(dt: number)
+	debug.profilebegin("UIParticleEmitter Step")
+	const props = self._props
+	const scaledDt = dt * (peek(props.TimeScale) or 1)
+
+	local env: Types.SimulationEnv = {
+		Drag = peek(props.Drag) or Defaults.Drag,
+		Gravity = Vector2.new(0, peek(props.Gravity) or Defaults.Gravity),
+		Wind = peek(props.Wind),
+	}
+
+	-- GUI inset compensation: prefer the (possibly destroyed) UI's ancestor,
+	-- fall back to the particles folder's during draining.
+	local inset = self._lastInset
+	const host: Instance? = if self.UI.Parent then self.UI else self._folder
+	const layerCollector = host and host:FindFirstAncestorWhichIsA("LayerCollector")
+	if layerCollector then
+		inset = layerCollector.AbsolutePosition.Y
+		self._lastInset = inset
+	end
+
+	-- Simulate, render, and reap in one pass (swap-remove keeps this O(n)).
+	const particles = self._particles
+	local i = 1
+	while particles[i] do
+		local particle = particles[i]
+		Simulation.Step(particle, scaledDt, env)
+		if particle.LifeTime <= 0 then
+			self._pool:Release(particle.Instance)
+			local last = #particles
+			particles[i] = particles[last]
+			particles[last] = nil
+		else
+			Simulation.ApplyVisuals(particle, inset)
+			i += 1
+		end
+	end
+
+	-- Continuous spawning
+	if not self._destroyed and peek(props.Enabled) then
+		const rate = Parse(props.Rate) or Defaults.Rate
+		if rate > 0 then
+			self._timeSinceLastSpawn += scaledDt
+			const spawnInterval = 1 / rate
+			while self._timeSinceLastSpawn >= spawnInterval do
+				self._timeSinceLastSpawn -= spawnInterval
+				self:_SpawnOne(PropResolver.ResolveSpawnParams(props, nil, self._rng), nil)
+			end
+		end
+	end
+
+	-- Lifecycle transitions once fully drained/idle
+	if #particles == 0 then
+		if self._destroyed then
+			self:_FinishDestroy()
+		elseif not peek(props.Enabled) then
+			self:_Disconnect()
+		end
+	end
+	debug.profileend()
+end
+
+--------------------------------------------------------------------------------
+-- Spawning
+--------------------------------------------------------------------------------
+
+function Emitter:_WarnOnce(reason: string)
+	if not self._warnedNoTarget then
+		self._warnedNoTarget = true
+		warn(`UIParticleEmitter: cannot spawn particles, {reason}`)
+	end
+end
+
+function Emitter:_SpawnOne(params: Types.SpawnParams, area: Types.SpawnAreaOverrides?)
+	local props = self._props
+	if params.LifeTime <= 0 then
+		return
+	end
+	if #self._particles >= (peek(props.MaxParticles) or Defaults.MaxParticles) then
+		return
+	end
+
+	local ui = self.UI :: Frame
+	if ui.Parent == nil then
+		self:_WarnOnce("the emitter UI has no parent")
+		return
+	end
+	local layerCollector = ui:FindFirstAncestorWhichIsA("LayerCollector")
+	if not layerCollector then
+		self:_WarnOnce("no LayerCollector ancestor found")
+		return
+	end
+	self._warnedNoTarget = false
+
+	local inset = layerCollector.AbsolutePosition.Y
+	self._lastInset = inset
+
+	-- Per-emitter particles folder, created lazily and reparented if the
+	-- emitter moved to a different LayerCollector.
+	local folder = self._folder
+	if not folder or folder.Parent == nil then
+		folder = Instance.new("Folder")
+		folder.Name = PARTICLES_FOLDER_NAME
+		folder.Parent = layerCollector
+		self._folder = folder
+	elseif folder.Parent ~= layerCollector then
+		folder.Parent = layerCollector
+	end
+
+	local containerPos, containerSize = computeSpawnArea(ui, layerCollector, area)
+
+	-- Bake constant size scales into the base size; only sequences animate.
+	local baseSize = params.Size
+	local sizeScaleSequence: NumberSequence? = nil
+	local initialScale = 1
+	if typeof(params.SizeScale) == "NumberSequence" then
+		sizeScaleSequence = params.SizeScale
+		initialScale = SequenceUtil.EvaluateNumberSequence(sizeScaleSequence, 0)
+	elseif params.SizeScale ~= nil then
+		baseSize *= params.SizeScale :: number
+	end
+
+	local colorSequence: ColorSequence? = if typeof(params.Color3) == "ColorSequence" then params.Color3 else nil
+	local initialColor: Color3 = if colorSequence
+		then SequenceUtil.EvaluateColorSequence(colorSequence, 0)
+		else params.Color3 :: Color3
+	local transparencySequence: NumberSequence? = if typeof(params.Transparency) == "NumberSequence"
+		then params.Transparency
+		else nil
+	local initialTransparency: number = if transparencySequence
+		then SequenceUtil.EvaluateNumberSequence(transparencySequence, 0)
+		else params.Transparency :: number
+
+	-- Start position, randomly distributed within the spawn area (or its
+	-- center when the area has no size).
+	local startX: number, startY: number
+	if containerSize.X > 0 and containerSize.Y > 0 then
+		startX = containerPos.X + self._rng:NextNumber() * containerSize.X
+		startY = containerPos.Y + self._rng:NextNumber() * containerSize.Y
+	else
+		startX = containerPos.X + containerSize.X / 2
+		startY = containerPos.Y + containerSize.Y / 2
+	end
+
+	local isImage = params.Image ~= nil
+	local instance = self._pool:Acquire(isImage)
+	local initialSize = baseSize * initialScale
+	instance.Size = UDim2.fromOffset(initialSize.X, initialSize.Y)
+	instance.Rotation = params.Rotation
+	instance.Position = UDim2.fromOffset(startX, startY - inset)
+	instance.Visible = peek(props.Visible) ~= false
+	if isImage then
+		local imageLabel = instance :: ImageLabel
+		imageLabel.Image = params.Image :: string
+		imageLabel.ImageColor3 = initialColor
+		imageLabel.ImageTransparency = initialTransparency
+	else
+		instance.BackgroundColor3 = initialColor
+		instance.BackgroundTransparency = initialTransparency
+	end
+	instance.Parent = folder
+
+	table.insert(self._particles, {
+		Instance = instance,
+		IsImage = isImage,
+		Position = Vector2.new(startX, startY),
+		Velocity = params.Velocity,
+		LifeTime = params.LifeTime,
+		InitialLifeTime = params.LifeTime,
+		Rotation = params.Rotation,
+		RotationSpeed = params.RotationSpeed,
+		BaseSize = baseSize,
+		SizeScaleSequence = sizeScaleSequence,
+		BaseColor = if colorSequence then nil else params.Color3 :: Color3,
+		ColorSequence = colorSequence,
+		TransparencySequence = transparencySequence,
+		BaseTransparency = if transparencySequence then nil else params.Transparency :: number,
+	})
+
+	self:_EnsureRunning()
+end
+
+--------------------------------------------------------------------------------
+-- Destruction
+--------------------------------------------------------------------------------
+
+function Emitter:_OnDestroyed()
+	if self._destroyed then
+		return
+	end
+	self._destroyed = true
+
+	if peek(self._props.CleanupParticlesImmediately) then
+		for _, particle in self._particles do
+			particle.Instance:Destroy()
+		end
+		table.clear(self._particles)
+	end
+
+	self._pool:Destroy()
+
+	if #self._particles == 0 then
+		self:_FinishDestroy()
+	else
+		-- Drain: keep stepping (outside the destroyed scope, intentionally)
+		-- until the last particle dies.
+		self:_EnsureRunning()
+	end
+end
+
+function Emitter:_FinishDestroy()
+	if self._dead then
+		return
+	end
+	self._dead = true
+	self:_Disconnect()
+	if self._folder then
+		self._folder:Destroy()
+		self._folder = nil
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Public API
+--------------------------------------------------------------------------------
+
+--[=[
+	@within UIParticleEmitter
+	@param config FireConfig? -- Optional per-burst overrides
+
+	Fires a burst of particles immediately. `Amount` defaults to the
+	emitter's `Rate`. All particle props may be overridden per burst, and the
+	spawn area may be overridden via `SpawnAreaPosition`,
+	`SpawnAreaAbsolutePosition`, `SpawnAreaAnchorPoint`, and `SpawnAreaSize`.
+	A no-op once the emitter has been destroyed.
+]=]
+function Emitter:Fire(config: Types.FireConfig?)
+	if self._destroyed then
+		return
+	end
+	local cfg: Types.FireConfig = config or {}
+	local props = self._props
+	local amount = Parse(cfg.Amount) or Parse(props.Rate) or Defaults.Rate
+
+	-- Spawn area overrides resolve once per burst, not per particle.
+	local area: Types.SpawnAreaOverrides = {
+		SpawnAreaPosition = Parse(cfg.SpawnAreaPosition),
+		SpawnAreaAbsolutePosition = Parse(cfg.SpawnAreaAbsolutePosition),
+		SpawnAreaAnchorPoint = Parse(cfg.SpawnAreaAnchorPoint),
+		SpawnAreaSize = Parse(cfg.SpawnAreaSize),
+	}
+
+	for _ = 1, amount do
+		self:_SpawnOne(PropResolver.ResolveSpawnParams(props, cfg, self._rng), area)
+	end
+end
+
+--[=[
+	@within UIParticleEmitter
+
+	Disconnects the update loop. Live particles freeze in place until the
+	loop restarts (via `Fire`, or `Enabled` becoming true again).
+]=]
+function Emitter:Stop()
+	self:_Disconnect()
+end
+
+--[=[
+	@within UIParticleEmitter
+
+	Immediately removes all live particles (recycling their instances into
+	the pool while the emitter is alive).
+]=]
+function Emitter:Clear()
+	for _, particle in self._particles do
+		self._pool:Release(particle.Instance)
+	end
+	table.clear(self._particles)
+	if self._destroyed then
+		self:_FinishDestroy()
+	end
+end
+
+--[=[
+	@within UIParticleEmitter
+	@return number -- The number of live particles
+
+	Returns the current number of live particles.
+]=]
+function Emitter:GetParticleCount(): number
+	return #self._particles
+end
+
+return Emitter

--- a/lib/uiparticleemitter/src/Emitter.luau
+++ b/lib/uiparticleemitter/src/Emitter.luau
@@ -2,7 +2,11 @@
 -- July 06, 2026
 --[[
 	The UIParticleEmitter Fusion component. Owns the spawn-area frame, the
-	per-emitter particles folder, the particle list/pool, and the update loop.
+	particle list, and the update loop. The particles folder and instance pool
+	are not owned per-emitter: they are shared across every emitter on the same
+	LayerCollector via PoolRegistry, so idle instances released by one emitter
+	can be reused by another. The emitter holds a pool handle for as long as it
+	has particles to render.
 
 	Lifecycle:
 	- The update loop runs only while there are live particles or the emitter
@@ -20,7 +24,7 @@ local RunService = game:GetService("RunService")
 
 --// Imports //--
 local Fusion = require("../Fusion")
-local ParticlePool = require("./ParticlePool")
+local PoolRegistry = require("./PoolRegistry")
 local PropResolver = require("./PropResolver")
 local SequenceUtil = require("./SequenceUtil")
 local Simulation = require("./Simulation")
@@ -34,8 +38,6 @@ local Defaults = PropResolver.Defaults
 -- emitter still works (and is testable) in plugin/server contexts.
 local STEP_SIGNAL: RBXScriptSignal = if RunService:IsClient() then RunService.RenderStepped else RunService.Heartbeat
 
-local PARTICLES_FOLDER_NAME = "UIParticles"
-
 local Emitter = {}
 Emitter.__index = Emitter
 
@@ -48,7 +50,13 @@ local function resolveUDim2(value: UDim2, containerSize: Vector2): (number, numb
 end
 
 -- Computes the absolute spawn rectangle. Fire() overrides win over the UI
--- frame's own geometry.
+-- frame's own geometry. Overridden UDim2 fields (SpawnAreaPosition/Size) are
+-- explicitly authored as fractions of the LayerCollector and are resolved
+-- against it; a field left un-overridden falls back to the UI's own
+-- Absolute* properties directly rather than re-resolving ui.Position/ui.Size
+-- against the LayerCollector -- those UDim2s are relative to ui.Parent, which
+-- may be nested arbitrarily deep under the LayerCollector and have a
+-- completely different size.
 local function computeSpawnArea(
 	ui: Frame,
 	layerCollector: LayerCollector,
@@ -68,21 +76,28 @@ local function computeSpawnArea(
 
 	local layerCollectorSize = layerCollector.AbsoluteSize
 
-	local sizeX, sizeY = resolveUDim2(area.SpawnAreaSize or ui.Size, layerCollectorSize)
-	local containerSize = Vector2.new(sizeX, sizeY)
-
-	local posX: number, posY: number
-	if area.SpawnAreaAbsolutePosition then
-		posX = area.SpawnAreaAbsolutePosition.X
-		posY = area.SpawnAreaAbsolutePosition.Y
+	local containerSize: Vector2
+	if area.SpawnAreaSize then
+		local sizeX, sizeY = resolveUDim2(area.SpawnAreaSize, layerCollectorSize)
+		containerSize = Vector2.new(sizeX, sizeY)
 	else
-		posX, posY = resolveUDim2(area.SpawnAreaPosition or ui.Position, layerCollectorSize)
+		containerSize = ui.AbsoluteSize
+	end
+
+	-- Where the anchor point sits in absolute space, independent of
+	-- containerSize (which may itself be overridden to a different size).
+	local anchorPos: Vector2
+	if area.SpawnAreaAbsolutePosition then
+		anchorPos = area.SpawnAreaAbsolutePosition
+	elseif area.SpawnAreaPosition then
+		local posX, posY = resolveUDim2(area.SpawnAreaPosition, layerCollectorSize)
+		anchorPos = Vector2.new(posX, posY)
+	else
+		anchorPos = ui.AbsolutePosition + ui.AnchorPoint * ui.AbsoluteSize
 	end
 
 	local anchor = area.SpawnAreaAnchorPoint or ui.AnchorPoint
-	local containerPos = Vector2.new(posX - anchor.X * containerSize.X, posY - anchor.Y * containerSize.Y)
-
-	return containerPos, containerSize
+	return anchorPos - anchor * containerSize, containerSize
 end
 
 --------------------------------------------------------------------------------
@@ -95,13 +110,13 @@ function Emitter.new(scope: Types.Scope<any>, props: Types.EmitterProps)
 	self._props = props
 	self._particles = {} :: { Types.Particle }
 	self._rng = if props.Seed then Random.new(props.Seed) else Random.new()
-	self._pool = ParticlePool.new(function()
+	self._maxSizeGetter = function()
 		return peek(props.MaxParticles) or Defaults.MaxParticles
-	end)
+	end
 	self._timeSinceLastSpawn = 0
 	self._lastInset = 0
 	self._connection = nil :: RBXScriptConnection?
-	self._folder = nil :: Folder?
+	self._poolHandle = nil :: PoolRegistry.Handle?
 	self._destroyed = false -- destruction initiated (no more spawning)
 	self._dead = false -- destruction finished (folder gone, loop stopped)
 	self._warnedNoTarget = false
@@ -187,10 +202,14 @@ function Emitter:_Step(dt: number)
 	}
 
 	-- GUI inset compensation: prefer the (possibly destroyed) UI's ancestor,
-	-- fall back to the particles folder's during draining.
+	-- fall back to the shared pool handle's LayerCollector during draining.
 	local inset = self._lastInset
-	const host: Instance? = if self.UI.Parent then self.UI else self._folder
-	const layerCollector = host and host:FindFirstAncestorWhichIsA("LayerCollector")
+	local layerCollector: LayerCollector? = nil
+	if self.UI.Parent then
+		layerCollector = self.UI:FindFirstAncestorWhichIsA("LayerCollector")
+	elseif self._poolHandle then
+		layerCollector = self._poolHandle.layerCollector
+	end
 	if layerCollector then
 		inset = layerCollector.AbsolutePosition.Y
 		self._lastInset = inset
@@ -203,7 +222,7 @@ function Emitter:_Step(dt: number)
 		local particle = particles[i]
 		Simulation.Step(particle, scaledDt, env)
 		if particle.LifeTime <= 0 then
-			self._pool:Release(particle.Instance)
+			(self._poolHandle :: PoolRegistry.Handle).pool:Release(particle.Instance)
 			local last = #particles
 			particles[i] = particles[last]
 			particles[last] = nil
@@ -248,6 +267,28 @@ function Emitter:_WarnOnce(reason: string)
 	end
 end
 
+-- Returns the shared pool handle for `layerCollector`, acquiring one on first
+-- use. If the emitter has migrated to a different LayerCollector, its live
+-- particles are moved into the new shared folder before the old handle is
+-- released (which may tear down the old shared folder/pool).
+function Emitter:_EnsurePoolHandle(layerCollector: LayerCollector): PoolRegistry.Handle
+	local old = self._poolHandle
+	if old and old.layerCollector == layerCollector then
+		return old
+	end
+
+	local handle = PoolRegistry.Acquire(layerCollector, self._maxSizeGetter)
+	self._poolHandle = handle
+	if old then
+		local folder = PoolRegistry.GetFolder(handle)
+		for _, particle in self._particles do
+			particle.Instance.Parent = folder
+		end
+		PoolRegistry.Release(old)
+	end
+	return handle
+end
+
 function Emitter:_SpawnOne(params: Types.SpawnParams, area: Types.SpawnAreaOverrides?)
 	local props = self._props
 	if params.LifeTime <= 0 then
@@ -272,17 +313,10 @@ function Emitter:_SpawnOne(params: Types.SpawnParams, area: Types.SpawnAreaOverr
 	local inset = layerCollector.AbsolutePosition.Y
 	self._lastInset = inset
 
-	-- Per-emitter particles folder, created lazily and reparented if the
-	-- emitter moved to a different LayerCollector.
-	local folder = self._folder
-	if not folder or folder.Parent == nil then
-		folder = Instance.new("Folder")
-		folder.Name = PARTICLES_FOLDER_NAME
-		folder.Parent = layerCollector
-		self._folder = folder
-	elseif folder.Parent ~= layerCollector then
-		folder.Parent = layerCollector
-	end
+	-- Shared per-LayerCollector particles folder + pool, acquired lazily and
+	-- re-acquired if the emitter moved to a different LayerCollector.
+	local handle = self:_EnsurePoolHandle(layerCollector)
+	local folder = PoolRegistry.GetFolder(handle)
 
 	local containerPos, containerSize = computeSpawnArea(ui, layerCollector, area)
 
@@ -320,7 +354,7 @@ function Emitter:_SpawnOne(params: Types.SpawnParams, area: Types.SpawnAreaOverr
 	end
 
 	local isImage = params.Image ~= nil
-	local instance = self._pool:Acquire(isImage)
+	local instance = handle.pool:Acquire(isImage)
 	local initialSize = baseSize * initialScale
 	instance.Size = UDim2.fromOffset(initialSize.X, initialSize.Y)
 	instance.Rotation = params.Rotation
@@ -374,8 +408,6 @@ function Emitter:_OnDestroyed()
 		table.clear(self._particles)
 	end
 
-	self._pool:Destroy()
-
 	if #self._particles == 0 then
 		self:_FinishDestroy()
 	else
@@ -391,9 +423,11 @@ function Emitter:_FinishDestroy()
 	end
 	self._dead = true
 	self:_Disconnect()
-	if self._folder then
-		self._folder:Destroy()
-		self._folder = nil
+	-- Drop our share of the pool; the registry tears down the shared folder
+	-- and pool once the last emitter on the LayerCollector releases.
+	if self._poolHandle then
+		PoolRegistry.Release(self._poolHandle)
+		self._poolHandle = nil
 	end
 end
 
@@ -449,8 +483,13 @@ end
 	the pool while the emitter is alive).
 ]=]
 function Emitter:Clear()
+	local handle = self._poolHandle
 	for _, particle in self._particles do
-		self._pool:Release(particle.Instance)
+		if handle then
+			handle.pool:Release(particle.Instance)
+		else
+			particle.Instance:Destroy()
+		end
 	end
 	table.clear(self._particles)
 	if self._destroyed then

--- a/lib/uiparticleemitter/src/Emitter.luau
+++ b/lib/uiparticleemitter/src/Emitter.luau
@@ -115,6 +115,7 @@ function Emitter.new(scope: Types.Scope<any>, props: Types.EmitterProps)
 	end
 	self._timeSinceLastSpawn = 0
 	self._lastInset = 0
+	self._lastEmitterPivot = nil :: Vector2? -- baseline for MaintainRelativePosition
 	self._connection = nil :: RBXScriptConnection?
 	self._poolHandle = nil :: PoolRegistry.Handle?
 	self._destroyed = false -- destruction initiated (no more spawning)
@@ -215,6 +216,23 @@ function Emitter:_Step(dt: number)
 		self._lastInset = inset
 	end
 
+	-- MaintainRelativePosition: rigidly translate the live particle cloud by
+	-- however far the emitter's pivot has moved since last frame, so the cloud
+	-- rides the emitter while world-space physics keeps running.
+	local followDelta: Vector2? = nil
+	if peek(props.MaintainRelativePosition) and self.UI.Parent then
+		local ui = self.UI :: Frame
+		local pivot = ui.AbsolutePosition + ui.AnchorPoint * ui.AbsoluteSize
+		if self._lastEmitterPivot then
+			followDelta = pivot - self._lastEmitterPivot
+		end
+		self._lastEmitterPivot = pivot
+	else
+		-- Disabled or draining (no parent): drop the baseline so re-enabling
+		-- later starts fresh instead of applying a stale jump.
+		self._lastEmitterPivot = nil
+	end
+
 	-- Simulate, render, and reap in one pass (swap-remove keeps this O(n)).
 	const particles = self._particles
 	local i = 1
@@ -227,6 +245,9 @@ function Emitter:_Step(dt: number)
 			particles[i] = particles[last]
 			particles[last] = nil
 		else
+			if followDelta then
+				particle.Position += followDelta
+			end
 			Simulation.ApplyVisuals(particle, inset)
 			i += 1
 		end

--- a/lib/uiparticleemitter/src/ParticlePool.luau
+++ b/lib/uiparticleemitter/src/ParticlePool.luau
@@ -69,6 +69,7 @@ function ParticlePool.Release(self: ParticlePool, instance: GuiObject)
 	end
 
 	instance.Visible = false
+	instance.Position = UDim2.fromScale(-2, -2) -- Shift far off screen
 	if instance:IsA("ImageLabel") then
 		table.insert(self._images, instance)
 	else

--- a/lib/uiparticleemitter/src/ParticlePool.luau
+++ b/lib/uiparticleemitter/src/ParticlePool.luau
@@ -1,9 +1,13 @@
 -- Authors: Logan Hunt (Raildex)
 -- July 06, 2026
 --[[
-	Per-emitter GuiObject pool. Reuses Frame/ImageLabel instances instead of
+	GuiObject pool. Reuses Frame/ImageLabel instances instead of
 	Instance.new/Destroy per particle. Released instances stay parented to the
 	particles folder with Visible = false to avoid reparent churn.
+
+	One pool is shared by every emitter on a given LayerCollector (see
+	PoolRegistry), so an instance released by one emitter can be re-acquired by
+	another in place.
 ]]
 
 local ParticlePool = {}

--- a/lib/uiparticleemitter/src/ParticlePool.luau
+++ b/lib/uiparticleemitter/src/ParticlePool.luau
@@ -1,0 +1,94 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	Per-emitter GuiObject pool. Reuses Frame/ImageLabel instances instead of
+	Instance.new/Destroy per particle. Released instances stay parented to the
+	particles folder with Visible = false to avoid reparent churn.
+]]
+
+local ParticlePool = {}
+ParticlePool.__index = ParticlePool
+
+export type ParticlePool = typeof(setmetatable(
+	{} :: {
+		_getMaxSize: () -> number,
+		_frames: { Frame },
+		_images: { ImageLabel },
+		_destroyed: boolean,
+	},
+	ParticlePool
+))
+
+function ParticlePool.new(getMaxSize: () -> number): ParticlePool
+	return setmetatable({
+		_getMaxSize = getMaxSize,
+		_frames = {},
+		_images = {},
+		_destroyed = false,
+	}, ParticlePool)
+end
+
+--[[
+	Pops a pooled instance of the requested kind, or creates a fresh one with
+	the static particle properties applied. The caller is responsible for
+	setting all per-particle properties (size, colors, rotation, position...).
+]]
+function ParticlePool.Acquire(self: ParticlePool, isImage: boolean): GuiObject
+	local pooled: GuiObject? = if isImage then table.remove(self._images) else table.remove(self._frames)
+	if pooled then
+		pooled.Visible = true
+		return pooled
+	end
+
+	local instance: GuiObject
+	if isImage then
+		local imageLabel = Instance.new("ImageLabel")
+		imageLabel.BackgroundTransparency = 1
+		instance = imageLabel
+	else
+		instance = Instance.new("Frame")
+	end
+	instance.AnchorPoint = Vector2.new(0.5, 0.5)
+	instance.BorderSizePixel = 0
+	instance.ZIndex = 10
+	return instance
+end
+
+--[[
+	Returns an instance to the pool (hidden, still parented), or destroys it
+	if the pool is full or has been destroyed.
+]]
+function ParticlePool.Release(self: ParticlePool, instance: GuiObject)
+	if self._destroyed or #self._frames + #self._images >= self._getMaxSize() then
+		instance:Destroy()
+		return
+	end
+
+	instance.Visible = false
+	if instance:IsA("ImageLabel") then
+		table.insert(self._images, instance)
+	else
+		table.insert(self._frames, instance :: Frame)
+	end
+end
+
+--[[
+	Destroys all pooled instances. Any instance released afterwards is
+	destroyed instead of pooled.
+]]
+function ParticlePool.Destroy(self: ParticlePool)
+	if self._destroyed then
+		return
+	end
+	self._destroyed = true
+	for _, instance in self._frames do
+		instance:Destroy()
+	end
+	for _, instance in self._images do
+		instance:Destroy()
+	end
+	table.clear(self._frames)
+	table.clear(self._images)
+end
+
+return ParticlePool

--- a/lib/uiparticleemitter/src/PoolRegistry.luau
+++ b/lib/uiparticleemitter/src/PoolRegistry.luau
@@ -1,0 +1,124 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 07, 2026
+--[[
+	Per-LayerCollector shared particle resources. Every emitter that spawns into
+	the same LayerCollector shares one `UIParticles` folder and one ParticlePool,
+	so an idle (recycled) instance released by one emitter can be reused by
+	another without reparent churn: released instances stay parented to the
+	shared folder, and any emitter on that LayerCollector re-acquires them in
+	place.
+
+	Each emitter holds a Handle. The shared folder and pool are created with the
+	first handle and destroyed when the last handle is released (refcounted). The
+	pool's idle cap is the sum of the live `MaxParticles` of every registered
+	emitter, so in the worst case -- every emitter releasing its full complement
+	at once -- they all still fit.
+]]
+
+local ParticlePool = require("./ParticlePool")
+
+local PARTICLES_FOLDER_NAME = "UIParticles"
+
+type Entry = {
+	layerCollector: LayerCollector,
+	folder: Folder,
+	pool: ParticlePool.ParticlePool,
+	getters: { [Handle]: () -> number },
+	count: number,
+}
+
+export type Handle = {
+	pool: ParticlePool.ParticlePool,
+	layerCollector: LayerCollector,
+	_entry: Entry,
+}
+
+local PoolRegistry = {}
+
+-- Live entries keyed by LayerCollector. Entries are inserted with the first
+-- Acquire and removed when the last handle is Released, so this never retains
+-- resources for a LayerCollector with no active emitters.
+local entries: { [LayerCollector]: Entry } = {}
+
+local function makeFolder(layerCollector: LayerCollector): Folder
+	local folder = Instance.new("Folder")
+	folder.Name = PARTICLES_FOLDER_NAME
+	folder.Parent = layerCollector
+	return folder
+end
+
+--[[
+	Registers an emitter against `layerCollector`, creating the shared folder and
+	pool on first use. `getMaxSize` reports that emitter's current live particle
+	cap; the shared pool's idle cap is the sum across all registered handles.
+]]
+function PoolRegistry.Acquire(layerCollector: LayerCollector, getMaxSize: () -> number): Handle
+	local entry = entries[layerCollector]
+	if not entry then
+		local created: Entry
+		created = {
+			layerCollector = layerCollector,
+			folder = makeFolder(layerCollector),
+			pool = ParticlePool.new(function()
+				local total = 0
+				for _, getter in created.getters do
+					total += getter()
+				end
+				return total
+			end),
+			getters = {},
+			count = 0,
+		}
+		entry = created
+		entries[layerCollector] = entry
+	end
+
+	local handle: Handle = {
+		pool = entry.pool,
+		layerCollector = layerCollector,
+		_entry = entry,
+	}
+	entry.getters[handle] = getMaxSize
+	entry.count += 1
+	return handle
+end
+
+--[[
+	Returns the shared folder, revalidating it first: the folder may have been
+	destroyed or re-homed externally, in which case it is recreated/reparented
+	under the LayerCollector.
+]]
+function PoolRegistry.GetFolder(handle: Handle): Folder
+	local entry = handle._entry
+	if entry.folder.Parent ~= entry.layerCollector then
+		if entry.folder.Parent == nil then
+			entry.folder = makeFolder(entry.layerCollector)
+		else
+			entry.folder.Parent = entry.layerCollector
+		end
+	end
+	return entry.folder
+end
+
+--[[
+	Deregisters a handle. When the last handle for a LayerCollector is released,
+	the shared pool and folder are destroyed. Idempotent: releasing an
+	already-released handle is a no-op.
+]]
+function PoolRegistry.Release(handle: Handle)
+	local entry = handle._entry
+	if entry.getters[handle] == nil then
+		return
+	end
+	entry.getters[handle] = nil
+	entry.count -= 1
+	if entry.count <= 0 then
+		entry.pool:Destroy()
+		if entry.folder.Parent then
+			entry.folder:Destroy()
+		end
+		entries[entry.layerCollector] = nil
+	end
+end
+
+return PoolRegistry

--- a/lib/uiparticleemitter/src/Presets.luau
+++ b/lib/uiparticleemitter/src/Presets.luau
@@ -1,0 +1,59 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	Prop-table factories for common particle looks. The emitter's built-in
+	defaults are neutral (white square, no motion); presets layer a look on
+	top and let caller overrides win.
+]]
+
+local Types = require("./Types")
+
+local Presets = {}
+
+--[=[
+	@within UIParticleEmitter
+	@function Confetti
+	@param overrides EmitterProps? -- Props merged over the preset (overrides win)
+	@return EmitterProps
+
+	Returns a props table for a classic confetti look: randomly hued strips
+	with random spin, tumbling under gravity. Accessible as
+	`UIParticleEmitter.Presets.Confetti`.
+
+	```lua
+	local confetti = UIParticleEmitter(scope, UIParticleEmitter.Presets.Confetti({
+		Parent = screenGui,
+		Rate = 30,
+	}))
+	confetti:Fire({ Amount = 100 })
+	```
+]=]
+function Presets.Confetti(overrides: Types.EmitterProps?): Types.EmitterProps
+	local rng = if overrides and overrides.Seed then Random.new(overrides.Seed) else Random.new()
+
+	local props: Types.EmitterProps = {
+		Size = function()
+			local length = rng:NextNumber(10, 20)
+			return Vector2.new(length, length * rng:NextNumber(0.4, 0.6))
+		end,
+		Color3 = function()
+			return Color3.fromHSV(rng:NextNumber(), 0.5, 1)
+		end,
+		Velocity = function()
+			return Vector2.new(rng:NextNumber(-30, 30), rng:NextNumber(-30, 30))
+		end,
+		Rotation = NumberRange.new(0, 360),
+		RotationSpeed = NumberRange.new(-100, 100),
+		LifeTime = NumberRange.new(2, 4),
+	}
+
+	if overrides then
+		for key, value in overrides :: any do
+			(props :: any)[key] = value
+		end
+	end
+
+	return props
+end
+
+return Presets

--- a/lib/uiparticleemitter/src/PropResolver.luau
+++ b/lib/uiparticleemitter/src/PropResolver.luau
@@ -1,0 +1,112 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	Resolves emitter props / Fire() overrides into concrete per-particle spawn
+	parameters. This is the single place where Getter values are unwrapped,
+	NumberRanges are rolled, and neutral defaults are applied — shared by both
+	the continuous spawn loop and manual Fire() bursts.
+]]
+
+local Fusion = require("../Fusion")
+local Types = require("./Types")
+
+local peek = Fusion.peek
+
+type Getter<T> = Types.Getter<T>
+
+local PropResolver = {}
+
+-- Neutral defaults, modeled after Roblox's ParticleEmitter conventions.
+-- The confetti look from the original component lives in Presets.Confetti.
+PropResolver.Defaults = {
+	Size = Vector2.new(10, 10),
+	Color3 = Color3.new(1, 1, 1),
+	Velocity = Vector2.zero,
+	Transparency = 0,
+	LifeTime = NumberRange.new(2, 4),
+	Rotation = 0,
+	RotationSpeed = 0,
+	Rate = 5,
+	Drag = 0.95,
+	Gravity = 500,
+	MaxParticles = 1000,
+}
+
+--[[
+	Unwraps a Getter<T>: peeks through Fusion state objects, then calls the
+	result if it is a generator function.
+]]
+function PropResolver.Parse<T>(getter: Getter<T>): T
+	local v = peek(getter)
+	if typeof(v) == "function" then
+		return v()
+	end
+	return v
+end
+
+--[[
+	Resolves a `number | NumberRange` into a concrete number, rolling within
+	the range using the provided Random instance.
+]]
+function PropResolver.ResolveRange(value: number | NumberRange, rng: Random): number
+	if typeof(value) == "NumberRange" then
+		return rng:NextNumber(value.Min, value.Max)
+	end
+	return value
+end
+
+local Parse = PropResolver.Parse
+local ResolveRange = PropResolver.ResolveRange
+
+--[[
+	Resolves one particle's spawn parameters. `overrides` (from Fire) win over
+	`props` (from the component), which win over the neutral defaults.
+]]
+function PropResolver.ResolveSpawnParams(
+	props: Types.EmitterProps,
+	overrides: Types.FireConfig?,
+	rng: Random
+): Types.SpawnParams
+	local function pick(key: string): any
+		if overrides and (overrides :: any)[key] ~= nil then
+			return (overrides :: any)[key]
+		end
+		return (props :: any)[key]
+	end
+
+	local defaults = PropResolver.Defaults
+
+	local size: Vector2 = Parse(pick("Size")) or defaults.Size
+	local sizeScale: (number | NumberSequence)? = Parse(pick("SizeScale"))
+	local color: Color3 | ColorSequence = Parse(pick("Color3")) or defaults.Color3
+	local image: string? = Parse(pick("Image"))
+	local velocity: Vector2 = Parse(pick("Velocity")) or defaults.Velocity
+	local transparency: number | NumberSequence = Parse(pick("Transparency")) or defaults.Transparency
+
+	local lifetime = Parse(pick("LifeTime"))
+	if lifetime == nil then
+		lifetime = defaults.LifeTime
+	end
+	local rotation = Parse(pick("Rotation"))
+	if rotation == nil then
+		rotation = defaults.Rotation
+	end
+	local rotationSpeed = Parse(pick("RotationSpeed"))
+	if rotationSpeed == nil then
+		rotationSpeed = defaults.RotationSpeed
+	end
+
+	return {
+		Size = size,
+		SizeScale = sizeScale,
+		Color3 = color,
+		Image = image,
+		Velocity = velocity,
+		Transparency = transparency,
+		LifeTime = ResolveRange(lifetime, rng),
+		Rotation = ResolveRange(rotation, rng),
+		RotationSpeed = ResolveRange(rotationSpeed, rng),
+	}
+end
+
+return PropResolver

--- a/lib/uiparticleemitter/src/PropResolver.luau
+++ b/lib/uiparticleemitter/src/PropResolver.luau
@@ -23,13 +23,13 @@ PropResolver.Defaults = {
 	Color3 = Color3.new(1, 1, 1),
 	Velocity = Vector2.zero,
 	Transparency = 0,
-	LifeTime = NumberRange.new(2, 4),
+	LifeTime = NumberRange.new(1, 1.5),
 	Rotation = 0,
 	RotationSpeed = 0,
 	Rate = 5,
 	Drag = 0.95,
 	Gravity = 500,
-	MaxParticles = 1000,
+	MaxParticles = 500,
 }
 
 --[[

--- a/lib/uiparticleemitter/src/SequenceUtil.luau
+++ b/lib/uiparticleemitter/src/SequenceUtil.luau
@@ -1,0 +1,78 @@
+--!strict
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	Pure evaluation of Roblox NumberSequence / ColorSequence values at a
+	normalized time (0-1). Keypoint envelopes are intentionally ignored;
+	values are linearly interpolated between keypoints.
+]]
+
+local SequenceUtil = {}
+
+--[=[
+	@within UIParticleEmitter
+	@function EvaluateNumberSequence
+	@private
+	@param sequence NumberSequence -- The sequence to evaluate
+	@param time number -- Normalized time from 0 to 1
+	@return number -- The linearly interpolated value
+
+	Evaluates a NumberSequence at a given time. Keypoint envelopes are ignored.
+]=]
+function SequenceUtil.EvaluateNumberSequence(sequence: NumberSequence, time: number): number
+	local keypoints = sequence.Keypoints
+
+	if time <= 0 then
+		return keypoints[1].Value
+	end
+	if time >= 1 then
+		return keypoints[#keypoints].Value
+	end
+
+	for i = 1, #keypoints - 1 do
+		local curr = keypoints[i]
+		local nextKeypoint = keypoints[i + 1]
+
+		if time >= curr.Time and time <= nextKeypoint.Time then
+			local alpha = (time - curr.Time) / (nextKeypoint.Time - curr.Time)
+			return curr.Value + (nextKeypoint.Value - curr.Value) * alpha
+		end
+	end
+
+	return keypoints[#keypoints].Value
+end
+
+--[=[
+	@within UIParticleEmitter
+	@function EvaluateColorSequence
+	@private
+	@param sequence ColorSequence -- The sequence to evaluate
+	@param time number -- Normalized time from 0 to 1
+	@return Color3 -- The linearly interpolated color
+
+	Evaluates a ColorSequence at a given time.
+]=]
+function SequenceUtil.EvaluateColorSequence(sequence: ColorSequence, time: number): Color3
+	local keypoints = sequence.Keypoints
+
+	if time <= 0 then
+		return keypoints[1].Value
+	end
+	if time >= 1 then
+		return keypoints[#keypoints].Value
+	end
+
+	for i = 1, #keypoints - 1 do
+		local curr = keypoints[i]
+		local nextKeypoint = keypoints[i + 1]
+
+		if time >= curr.Time and time <= nextKeypoint.Time then
+			local alpha = (time - curr.Time) / (nextKeypoint.Time - curr.Time)
+			return curr.Value:Lerp(nextKeypoint.Value, alpha)
+		end
+	end
+
+	return keypoints[#keypoints].Value
+end
+
+return SequenceUtil

--- a/lib/uiparticleemitter/src/Simulation.luau
+++ b/lib/uiparticleemitter/src/Simulation.luau
@@ -1,0 +1,99 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	Pure particle physics and visual evaluation. `Step` mutates only the plain
+	numeric fields of a particle table (never the Instance), so it can be
+	tested deterministically. `ApplyVisuals` is the one place that writes the
+	simulated state to the particle's GuiObject.
+]]
+
+local SequenceUtil = require("./SequenceUtil")
+local Types = require("./Types")
+
+local Simulation = {}
+
+--[[
+	Advances a particle's physics by `dt` seconds: position integration, drag,
+	gravity, wind, rotation, and lifetime countdown.
+]]
+function Simulation.Step(particle: Types.Particle, dt: number, env: Types.SimulationEnv)
+	particle.Position += particle.Velocity * dt
+
+	particle.Velocity *= 1 - env.Drag * dt
+	particle.Velocity += env.Gravity * dt
+
+	local wind = env.Wind
+	if wind then
+		local windForce: Vector2 = if typeof(wind) == "function" then wind(particle.Position) else wind
+		particle.Velocity += windForce * dt
+	end
+
+	particle.Rotation += particle.RotationSpeed * dt
+	particle.LifeTime -= dt
+end
+
+--[[
+	Returns the particle's normalized lifetime: 0 at spawn, 1 at death.
+]]
+function Simulation.GetNormalizedLifetime(particle: Types.Particle): number
+	return 1 - math.clamp(particle.LifeTime / particle.InitialLifeTime, 0, 1)
+end
+
+--[[
+	Computes the particle's current visual state (size, color, transparency)
+	from its sequences at the current normalized lifetime. Pure.
+]]
+function Simulation.ComputeVisuals(particle: Types.Particle): (Vector2, Color3, number)
+	local t = Simulation.GetNormalizedLifetime(particle)
+
+	local size = particle.BaseSize
+	if particle.SizeScaleSequence then
+		size = size * SequenceUtil.EvaluateNumberSequence(particle.SizeScaleSequence, t)
+	end
+
+	local color: Color3
+	if particle.ColorSequence then
+		color = SequenceUtil.EvaluateColorSequence(particle.ColorSequence, t)
+	else
+		color = particle.BaseColor :: Color3
+	end
+
+	local transparency: number
+	if particle.TransparencySequence then
+		transparency = SequenceUtil.EvaluateNumberSequence(particle.TransparencySequence, t)
+	else
+		transparency = particle.BaseTransparency or 0
+	end
+
+	return size, color, transparency
+end
+
+--[[
+	Writes the particle's simulated state to its GuiObject. `inset` is the
+	LayerCollector's Y AbsolutePosition (GUI inset compensation).
+]]
+function Simulation.ApplyVisuals(particle: Types.Particle, inset: number)
+	local size, color, transparency = Simulation.ComputeVisuals(particle)
+	local instance = particle.Instance
+
+	if particle.SizeScaleSequence then
+		instance.Size = UDim2.fromOffset(size.X, size.Y)
+	end
+
+	if particle.RotationSpeed ~= 0 then
+		instance.Rotation = particle.Rotation
+	end
+
+	if particle.IsImage then
+		local imageLabel = instance :: ImageLabel
+		imageLabel.ImageColor3 = color
+		imageLabel.ImageTransparency = transparency
+	else
+		instance.BackgroundColor3 = color
+		instance.BackgroundTransparency = transparency
+	end
+
+	instance.Position = UDim2.fromOffset(particle.Position.X, particle.Position.Y - inset)
+end
+
+return Simulation

--- a/lib/uiparticleemitter/src/Tests/UPE.Emitter.spec.luau
+++ b/lib/uiparticleemitter/src/Tests/UPE.Emitter.spec.luau
@@ -145,6 +145,82 @@ return function(tiniest)
 		end)
 	end)
 
+	describe("nested parent spawn area (regression)", function()
+		-- The emitter's UI is parented a level below a Frame with a fixed
+		-- (offset-based) size, so its AbsoluteSize/AbsolutePosition differ
+		-- from the ScreenGui's own -- exposing any fallback path that mixes
+		-- ui.Size/ui.Position up with the LayerCollector's AbsoluteSize.
+		local function setupNested(sizeScale: Vector2)
+			local gui = Instance.new("ScreenGui")
+			gui.Parent = game:GetService("StarterGui")
+
+			local container = Instance.new("Frame")
+			container.Size = UDim2.fromOffset(400, 300)
+			container.BackgroundTransparency = 1
+			container.Parent = gui
+
+			local scope = Fusion.scoped(Fusion)
+			local emitter = UIParticleEmitter(scope, {
+				Parent = container,
+				LifeTime = SAFE_LIFETIME,
+				SpawnAreaAnchorPoint = Vector2.new(0.5, 0.5),
+				SpawnAreaPosition = UDim2.fromScale(0.5, 0.5),
+				SpawnAreaSize = UDim2.fromScale(sizeScale.X, sizeScale.Y),
+			})
+
+			local function cleanup()
+				emitter:Clear()
+				Fusion.doCleanup(scope)
+				gui:Destroy()
+			end
+			return emitter, cleanup
+		end
+
+		-- Bounds check plus a spread check: a buggy fallback that collapses
+		-- containerSize to (0, 0) would put every particle at exactly
+		-- `center`, which a bounds-only check wouldn't catch.
+		local function assertParticlesWithin(emitter, center: Vector2, size: Vector2)
+			local half = size / 2
+			local first = emitter._particles[1].Position
+			local allSame = true
+			for _, particle in emitter._particles do
+				local pos = particle.Position
+				expect(pos.X >= center.X - half.X - 0.01).is_true()
+				expect(pos.X <= center.X + half.X + 0.01).is_true()
+				expect(pos.Y >= center.Y - half.Y - 0.01).is_true()
+				expect(pos.Y <= center.Y + half.Y + 0.01).is_true()
+				if pos ~= first then
+					allSame = false
+				end
+			end
+			expect(allSame).never_is_true()
+		end
+
+		test("size falls back to the UI's own AbsoluteSize when only Position is overridden", function()
+			local emitter, cleanup = setupNested(Vector2.new(0.5, 0.5))
+			expect(emitter.UI.AbsoluteSize).is(Vector2.new(200, 150))
+
+			emitter:Fire { Amount = 20, SpawnAreaAbsolutePosition = Vector2.new(5000, 5000) }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(20)
+
+			assertParticlesWithin(emitter, Vector2.new(5000, 5000), Vector2.new(200, 150))
+			cleanup()
+		end)
+
+		test("position falls back to the UI's own AbsolutePosition when only Size is overridden", function()
+			local emitter, cleanup = setupNested(Vector2.new(0.5, 0.5))
+			local expectedCenter = emitter.UI.AbsolutePosition + emitter.UI.AbsoluteSize / 2
+
+			emitter:Fire { Amount = 20, SpawnAreaSize = UDim2.fromOffset(60, 60) }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(20)
+
+			assertParticlesWithin(emitter, expectedCenter, Vector2.new(60, 60))
+			cleanup()
+		end)
+	end)
+
 	describe("MaxParticles", function()
 		test("explicit cap drops excess spawns", function()
 			local emitter, _, _, cleanup = setup { MaxParticles = 5 }
@@ -228,6 +304,95 @@ return function(tiniest)
 				expect((child :: GuiObject).Visible).never_is_true()
 			end
 			cleanup()
+		end)
+	end)
+
+	describe("shared pool", function()
+		-- Two emitters parented under the same LayerCollector share a single
+		-- UIParticles folder and instance pool.
+		local function setupPair(props: { [string]: any }?)
+			local gui = Instance.new("ScreenGui")
+			gui.Parent = game:GetService("StarterGui")
+
+			local function make()
+				local scope = Fusion.scoped(Fusion)
+				local emitterProps: { [string]: any } = { Parent = gui, LifeTime = SAFE_LIFETIME }
+				for key, value in props or {} do
+					emitterProps[key] = value
+				end
+				return UIParticleEmitter(scope, emitterProps), scope
+			end
+
+			local a, aScope = make()
+			local b, bScope = make()
+			local function cleanup()
+				a:Clear()
+				b:Clear()
+				Fusion.doCleanup(aScope)
+				Fusion.doCleanup(bScope)
+				gui:Destroy()
+			end
+			return a, aScope, b, bScope, gui, cleanup
+		end
+
+		local function countFolders(gui: ScreenGui): number
+			local n = 0
+			for _, child in gui:GetChildren() do
+				if child.Name == "UIParticles" then
+					n += 1
+				end
+			end
+			return n
+		end
+
+		test("emitters on the same LayerCollector share one folder", function()
+			local a, _, b, _, gui, cleanup = setupPair()
+			a:Fire { Amount = 2 }
+			a:Stop()
+			b:Fire { Amount = 3 }
+			b:Stop()
+
+			expect(countFolders(gui)).is(1)
+			expect(#(getFolder(gui) :: Folder):GetChildren()).is(5)
+			cleanup()
+		end)
+
+		test("idle instances released by one emitter are reused by another", function()
+			local a, _, b, _, gui, cleanup = setupPair { LifeTime = 1 }
+
+			-- a spawns 3, then lets them die back into the shared pool.
+			a:Fire { Amount = 3 }
+			a:Stop()
+			a:_Step(2)
+			expect(a:GetParticleCount()).is(0)
+			local folder = getFolder(gui) :: Folder
+			expect(#folder:GetChildren()).is(3)
+
+			-- b reuses those 3 idle instances in place -- no new instances.
+			b:Fire { Amount = 3 }
+			b:Stop()
+			expect(b:GetParticleCount()).is(3)
+			expect(#folder:GetChildren()).is(3)
+			cleanup()
+		end)
+
+		test("the shared folder is torn down only when the last emitter dies", function()
+			local a, aScope, b, bScope, gui, _ = setupPair { CleanupParticlesImmediately = true }
+			a:Fire { Amount = 1 }
+			a:Stop()
+			b:Fire { Amount = 1 }
+			b:Stop()
+			local folder = getFolder(gui) :: Folder
+			expect(folder.Parent).exists()
+
+			-- Destroying one emitter leaves the shared folder alive for the other.
+			Fusion.doCleanup(bScope)
+			expect(folder.Parent).exists()
+
+			-- Destroying the last one releases the shared resources.
+			Fusion.doCleanup(aScope)
+			expect(folder.Parent).never_exists()
+			gui:Destroy()
 		end)
 	end)
 
@@ -407,6 +572,14 @@ return function(tiniest)
 
 		test("the story module has the UI Labs shape", function()
 			local story = require("../UIParticleEmitter.story") :: any
+			expect(story).is_a("table")
+			expect(typeof(story.story)).is("function")
+			expect(story.controls).is_a("table")
+			expect(story.fusion).exists()
+		end)
+
+		test("the nested-parent story module has the UI Labs shape", function()
+			local story = require("../UIParticleEmitterNestedParent.story") :: any
 			expect(story).is_a("table")
 			expect(typeof(story.story)).is("function")
 			expect(story.controls).is_a("table")

--- a/lib/uiparticleemitter/src/Tests/UPE.Emitter.spec.luau
+++ b/lib/uiparticleemitter/src/Tests/UPE.Emitter.spec.luau
@@ -431,6 +431,85 @@ return function(tiniest)
 		end)
 	end)
 
+	describe("MaintainRelativePosition", function()
+		-- The emitter UI is scale-sized (0, 0), so its pivot equals its
+		-- AbsolutePosition; moving UI.Position shifts the pivot by the same
+		-- absolute delta. Steps use dt = 0 so the only thing that can move a
+		-- particle is the emitter-follow translation (physics contributes 0).
+
+		test("live particles follow the emitter when enabled", function()
+			local emitter, _, _, cleanup = setup { MaintainRelativePosition = true }
+			emitter:Fire { Amount = 3 }
+			emitter:Stop()
+
+			emitter.UI.Position = UDim2.fromOffset(100, 100)
+			emitter:_Step(0) -- establish the pivot baseline
+			local pivotBefore = emitter.UI.AbsolutePosition
+			local partBefore = emitter._particles[1].Position
+
+			emitter.UI.Position = UDim2.fromOffset(150, 130)
+			emitter:_Step(0)
+			local delta = emitter.UI.AbsolutePosition - pivotBefore
+			local partAfter = emitter._particles[1].Position
+
+			expect(partAfter.X - partBefore.X).is(delta.X)
+			expect(partAfter.Y - partBefore.Y).is(delta.Y)
+			cleanup()
+		end)
+
+		test("particles stay in screen space when disabled (default)", function()
+			local emitter, _, _, cleanup = setup()
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+
+			emitter:_Step(0)
+			local before = emitter._particles[1].Position
+			emitter.UI.Position = UDim2.fromOffset(300, 300)
+			emitter:_Step(0)
+			expect(emitter._particles[1].Position).is(before)
+			cleanup()
+		end)
+
+		test("toggling on mid-flight starts fresh without a stale jump", function()
+			local gui = Instance.new("ScreenGui")
+			gui.Parent = game:GetService("StarterGui")
+			local scope = Fusion.scoped(Fusion)
+			local maintain = scope:Value(false)
+			local emitter = UIParticleEmitter(scope, {
+				Parent = gui,
+				LifeTime = SAFE_LIFETIME,
+				MaintainRelativePosition = maintain,
+			})
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+
+			-- While disabled, move the emitter far away; the particle must not move.
+			emitter:_Step(0)
+			local before = emitter._particles[1].Position
+			emitter.UI.Position = UDim2.fromOffset(500, 500)
+			emitter:_Step(0)
+			expect(emitter._particles[1].Position).is(before)
+
+			-- Enabling establishes a fresh baseline at the current pivot: the
+			-- 500px move above must not retroactively jump the particle.
+			maintain:set(true)
+			emitter:_Step(0)
+			expect(emitter._particles[1].Position).is(before)
+
+			-- A subsequent move now shifts the particle.
+			local pivotBefore = emitter.UI.AbsolutePosition
+			emitter.UI.Position = UDim2.fromOffset(560, 540)
+			emitter:_Step(0)
+			local delta = emitter.UI.AbsolutePosition - pivotBefore
+			expect(emitter._particles[1].Position.X - before.X).is(delta.X)
+			expect(emitter._particles[1].Position.Y - before.Y).is(delta.Y)
+
+			emitter:Clear()
+			Fusion.doCleanup(scope)
+			gui:Destroy()
+		end)
+	end)
+
 	describe("Enabled", function()
 		test("constant Enabled = true spawns continuously", function()
 			-- Rate 4 -> exact 0.25s spawn interval (binary-exact), so one

--- a/lib/uiparticleemitter/src/Tests/UPE.Emitter.spec.luau
+++ b/lib/uiparticleemitter/src/Tests/UPE.Emitter.spec.luau
@@ -1,0 +1,416 @@
+--[[
+	Emitter component coverage: spawning, caps, pooling, lifecycle (idle /
+	active / draining / dead), Enabled handling, and destruction semantics.
+
+	Determinism pattern: the emitter connects to a real RunService signal, so
+	tests call :Stop() right after spawning (killing the live connection)
+	and then drive the private :_Step(dt) manually to simulate time. Never
+	yield between spawning and :Stop(), or real frames may interleave.
+]]
+
+return function(tiniest)
+	local Fusion = require("../../Fusion")
+	local UIParticleEmitter = require(script.Parent.Parent :: any) :: any
+
+	local describe = tiniest.describe
+	local test = tiniest.test
+	local expect = tiniest.expect
+
+	-- Long default lifetime so stray real frames between calls can't expire
+	-- particles; tests that need expiry override LifeTime themselves.
+	local SAFE_LIFETIME = 60
+
+	local function setup(props: { [string]: any }?)
+		local gui = Instance.new("ScreenGui")
+		gui.Name = "UPE_TestGui"
+		gui.Parent = game:GetService("StarterGui")
+		local scope = Fusion.scoped(Fusion)
+
+		local emitterProps: { [string]: any } = {
+			Parent = gui,
+			LifeTime = SAFE_LIFETIME,
+		}
+		for key, value in props or {} do
+			emitterProps[key] = value
+		end
+
+		local emitter = UIParticleEmitter(scope, emitterProps)
+		local function cleanup()
+			emitter:Clear()
+			Fusion.doCleanup(scope)
+			gui:Destroy()
+		end
+		return emitter, scope, gui, cleanup
+	end
+
+	local function getFolder(gui: ScreenGui): Folder?
+		return gui:FindFirstChild("UIParticles") :: Folder?
+	end
+
+	describe("spawning", function()
+		test("Fire spawns particles into a per-emitter folder", function()
+			local emitter, _, gui, cleanup = setup()
+			emitter:Fire { Amount = 10 }
+			emitter:Stop()
+
+			expect(emitter:GetParticleCount()).is(10)
+			local folder = getFolder(gui)
+			expect(folder).exists()
+			expect(#(folder :: Folder):GetChildren()).is(10)
+			cleanup()
+		end)
+
+		test("Fire with no config uses Rate as the amount", function()
+			local emitter, _, _, cleanup = setup { Rate = 7 }
+			emitter:Fire()
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(7)
+			cleanup()
+		end)
+
+		test("image particles are ImageLabels", function()
+			local emitter, _, gui, cleanup = setup()
+			emitter:Fire { Amount = 1, Image = "rbxassetid://123" }
+			emitter:Stop()
+
+			local child = (getFolder(gui) :: Folder):GetChildren()[1]
+			expect(child:IsA("ImageLabel")).is_true()
+			expect((child :: ImageLabel).Image).is("rbxassetid://123")
+			cleanup()
+		end)
+
+		test("constant SizeScale bakes into the spawn size", function()
+			local emitter, _, gui, cleanup = setup { Size = Vector2.new(10, 10), SizeScale = 2 }
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+
+			local child = (getFolder(gui) :: Folder):GetChildren()[1] :: GuiObject
+			expect(child.Size).is(UDim2.fromOffset(20, 20))
+			cleanup()
+		end)
+
+		test("SizeScale sequences animate size over lifetime", function()
+			local emitter, _, gui, cleanup = setup {
+				Size = Vector2.new(10, 10),
+				SizeScale = NumberSequence.new(1, 2),
+				LifeTime = 1,
+				TimeScale = 1,
+			}
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+
+			local child = (getFolder(gui) :: Folder):GetChildren()[1] :: GuiObject
+			expect(child.Size).is(UDim2.fromOffset(10, 10))
+			emitter:_Step(0.5)
+			expect(child.Size).is(UDim2.fromOffset(15, 15))
+			cleanup()
+		end)
+
+		test("Fire spawn-area overrides position particles within the area", function()
+			local emitter, _, _, cleanup = setup()
+			emitter:Fire {
+				Amount = 5,
+				SpawnAreaAbsolutePosition = Vector2.new(300, 400),
+				SpawnAreaSize = UDim2.fromOffset(50, 50),
+				SpawnAreaAnchorPoint = Vector2.new(0.5, 0.5),
+			}
+			emitter:Stop()
+
+			expect(emitter:GetParticleCount()).is(5)
+			for _, particle in emitter._particles do
+				expect(particle.Position.X >= 275 and particle.Position.X <= 325).is_true()
+				expect(particle.Position.Y >= 375 and particle.Position.Y <= 425).is_true()
+			end
+			cleanup()
+		end)
+
+		test("non-positive lifetimes are dropped", function()
+			local emitter, _, _, cleanup = setup()
+			emitter:Fire { Amount = 3, LifeTime = 0 }
+			expect(emitter:GetParticleCount()).is(0)
+			cleanup()
+		end)
+
+		test("Fire without a parent warns once and spawns nothing", function()
+			local scope = Fusion.scoped(Fusion)
+			local emitter = UIParticleEmitter(scope, {})
+			expect(function()
+				emitter:Fire { Amount = 1 }
+			end).warns()
+			expect(function()
+				emitter:Fire { Amount = 1 }
+			end).never_warns()
+			expect(emitter:GetParticleCount()).is(0)
+			Fusion.doCleanup(scope)
+		end)
+	end)
+
+	describe("MaxParticles", function()
+		test("explicit cap drops excess spawns", function()
+			local emitter, _, _, cleanup = setup { MaxParticles = 5 }
+			emitter:Fire { Amount = 20 }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(5)
+			cleanup()
+		end)
+
+		test("default cap is 500", function()
+			local emitter, _, _, cleanup = setup()
+			emitter:Fire { Amount = 600 }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(500)
+			cleanup()
+		end)
+	end)
+
+	describe("pooling", function()
+		test("expired particles are hidden and reused, not destroyed", function()
+			local emitter, _, gui, cleanup = setup { LifeTime = 1 }
+			emitter:Fire { Amount = 3 }
+			emitter:Stop()
+			emitter:_Step(2)
+
+			expect(emitter:GetParticleCount()).is(0)
+			local folder = getFolder(gui) :: Folder
+			expect(#folder:GetChildren()).is(3)
+			for _, child in folder:GetChildren() do
+				expect((child :: GuiObject).Visible).never_is_true()
+			end
+
+			-- Refiring reuses the pooled instances rather than creating more
+			emitter:Fire { Amount = 3 }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(3)
+			expect(#folder:GetChildren()).is(3)
+			cleanup()
+		end)
+
+		test("pool shrinks when MaxParticles decreases", function()
+			local gui = Instance.new("ScreenGui")
+			gui.Parent = game:GetService("StarterGui")
+			local scope = Fusion.scoped(Fusion)
+			local maxParticles = scope:Value(3)
+			local emitter = UIParticleEmitter(scope, {
+				Parent = gui,
+				LifeTime = 1,
+				MaxParticles = maxParticles,
+			})
+
+			emitter:Fire { Amount = 5 }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(3)
+			emitter:_Step(2)
+			local folder = getFolder(gui) :: Folder
+			expect(#folder:GetChildren()).is(3)
+
+			-- With the cap lowered, dying particles no longer fit in the pool
+			maxParticles:set(1)
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+			expect(emitter:GetParticleCount()).is(1)
+			emitter:_Step(2)
+			expect(#folder:GetChildren()).is(2)
+
+			Fusion.doCleanup(scope)
+			gui:Destroy()
+		end)
+
+		test("Clear recycles live particles into the pool", function()
+			local emitter, _, gui, cleanup = setup()
+			emitter:Fire { Amount = 4 }
+			emitter:Stop()
+			emitter:Clear()
+
+			expect(emitter:GetParticleCount()).is(0)
+			local folder = getFolder(gui) :: Folder
+			expect(#folder:GetChildren()).is(4)
+			for _, child in folder:GetChildren() do
+				expect((child :: GuiObject).Visible).never_is_true()
+			end
+			cleanup()
+		end)
+	end)
+
+	describe("stepping", function()
+		test("particles move under simulation when stepped", function()
+			local emitter, _, gui, cleanup = setup {
+				Velocity = Vector2.new(100, 0),
+				Gravity = 0,
+				Drag = 0,
+			}
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+
+			local child = (getFolder(gui) :: Folder):GetChildren()[1] :: GuiObject
+			local before = child.Position.X.Offset
+			emitter:_Step(1)
+			expect(child.Position.X.Offset > before).is_true()
+			cleanup()
+		end)
+
+		test("TimeScale = 0 freezes lifetime and motion", function()
+			local emitter, _, _, cleanup = setup { LifeTime = 1, TimeScale = 0 }
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+			emitter:_Step(5)
+			expect(emitter:GetParticleCount()).is(1)
+			cleanup()
+		end)
+
+		test("Stop halts the update loop", function()
+			local emitter, _, _, cleanup = setup()
+			emitter:Fire { Amount = 1 }
+			emitter:Stop()
+			expect(emitter._connection).never_exists()
+			cleanup()
+		end)
+	end)
+
+	describe("Enabled", function()
+		test("constant Enabled = true spawns continuously", function()
+			-- Rate 4 -> exact 0.25s spawn interval (binary-exact), so one
+			-- 1-second step spawns exactly 4.
+			local emitter, _, _, cleanup = setup { Enabled = true, Rate = 4 }
+			emitter:Stop()
+			emitter:_Step(1)
+			expect(emitter:GetParticleCount()).is(4)
+			cleanup()
+		end)
+
+		test("Enabled = nil constructs without error and stays idle", function()
+			local emitter, _, _, cleanup = setup()
+			expect(emitter:GetParticleCount()).is(0)
+			expect(emitter._connection).never_exists()
+			cleanup()
+		end)
+
+		test("Enabled as a Fusion Value starts the emitter when set", function()
+			local gui = Instance.new("ScreenGui")
+			gui.Parent = game:GetService("StarterGui")
+			local scope = Fusion.scoped(Fusion)
+			local enabled = scope:Value(false)
+			local emitter = UIParticleEmitter(scope, {
+				Parent = gui,
+				LifeTime = SAFE_LIFETIME,
+				Enabled = enabled,
+				Rate = 4,
+			})
+			expect(emitter:GetParticleCount()).is(0)
+
+			enabled:set(true)
+			emitter:Stop()
+			emitter:_Step(1)
+			expect(emitter:GetParticleCount()).is(4)
+
+			-- Disabling stops spawning; existing particles keep simulating
+			enabled:set(false)
+			emitter:_Step(1)
+			expect(emitter:GetParticleCount()).is(4)
+
+			emitter:Clear()
+			Fusion.doCleanup(scope)
+			gui:Destroy()
+		end)
+	end)
+
+	describe("Visible", function()
+		test("toggling a Visible state hides live particles", function()
+			local gui = Instance.new("ScreenGui")
+			gui.Parent = game:GetService("StarterGui")
+			local scope = Fusion.scoped(Fusion)
+			local visible = scope:Value(true)
+			local emitter = UIParticleEmitter(scope, {
+				Parent = gui,
+				LifeTime = SAFE_LIFETIME,
+				Visible = visible,
+			})
+			emitter:Fire { Amount = 2 }
+			emitter:Stop()
+
+			visible:set(false)
+			for _, child in (getFolder(gui) :: Folder):GetChildren() do
+				expect((child :: GuiObject).Visible).never_is_true()
+			end
+			visible:set(true)
+			for _, child in (getFolder(gui) :: Folder):GetChildren() do
+				expect((child :: GuiObject).Visible).is_true()
+			end
+
+			emitter:Clear()
+			Fusion.doCleanup(scope)
+			gui:Destroy()
+		end)
+	end)
+
+	describe("destruction", function()
+		test("particles outlive the scope by default, then drain", function()
+			local emitter, scope, gui, _ = setup()
+			emitter:Fire { Amount = 5 }
+			emitter:Stop()
+			local folder = getFolder(gui) :: Folder
+
+			Fusion.doCleanup(scope)
+
+			-- Spawning is dead, but the particles live on
+			expect(emitter:GetParticleCount()).is(5)
+			expect(#folder:GetChildren()).is(5)
+			emitter:Fire { Amount = 3 }
+			expect(emitter:GetParticleCount()).is(5)
+
+			-- Draining: once the last particle expires everything cleans up
+			emitter:_Step(SAFE_LIFETIME + 1)
+			expect(emitter:GetParticleCount()).is(0)
+			expect(folder.Parent).never_exists()
+			expect(emitter._connection).never_exists()
+			gui:Destroy()
+		end)
+
+		test("CleanupParticlesImmediately destroys particles with the scope", function()
+			local emitter, scope, gui, _ = setup { CleanupParticlesImmediately = true }
+			emitter:Fire { Amount = 5 }
+			emitter:Stop()
+			local folder = getFolder(gui) :: Folder
+
+			Fusion.doCleanup(scope)
+
+			expect(emitter:GetParticleCount()).is(0)
+			expect(folder.Parent).never_exists()
+			expect(emitter._connection).never_exists()
+			gui:Destroy()
+		end)
+
+		test("destroying the UI directly also ends the emitter", function()
+			local emitter, scope, gui, _ = setup { CleanupParticlesImmediately = true }
+			emitter:Fire { Amount = 2 }
+			emitter:Stop()
+
+			emitter.UI:Destroy()
+			expect(emitter:GetParticleCount()).is(0)
+			emitter:Fire { Amount = 1 }
+			expect(emitter:GetParticleCount()).is(0)
+
+			Fusion.doCleanup(scope)
+			gui:Destroy()
+		end)
+	end)
+
+	describe("entry point", function()
+		test("Presets.Confetti returns a props table and overrides win", function()
+			local props = UIParticleEmitter.Presets.Confetti { Rate = 30, Seed = 5 }
+			expect(props.Rate).is(30)
+			expect(typeof(props.Size)).is("function")
+			expect(typeof(props.Color3)).is("function")
+			expect(typeof(props.Size())).is("Vector2")
+			expect(typeof(props.Color3())).is("Color3")
+			expect(typeof(props.LifeTime)).is("NumberRange")
+		end)
+
+		test("the story module has the UI Labs shape", function()
+			local story = require("../UIParticleEmitter.story") :: any
+			expect(story).is_a("table")
+			expect(typeof(story.story)).is("function")
+			expect(story.controls).is_a("table")
+			expect(story.fusion).exists()
+		end)
+	end)
+end

--- a/lib/uiparticleemitter/src/Tests/UPE.PropResolver.spec.luau
+++ b/lib/uiparticleemitter/src/Tests/UPE.PropResolver.spec.luau
@@ -1,0 +1,138 @@
+--[[
+	PropResolver coverage: Getter unwrapping, NumberRange rolling, neutral
+	defaults, and Fire-override precedence.
+]]
+
+return function(tiniest)
+	local Fusion = require("../../Fusion")
+	local PropResolver = require("../PropResolver")
+
+	local describe = tiniest.describe
+	local test = tiniest.test
+	local expect = tiniest.expect
+
+	describe("Parse", function()
+		test("passes constants through", function()
+			expect(PropResolver.Parse(5)).is(5)
+			expect(PropResolver.Parse("abc")).is("abc")
+			expect(PropResolver.Parse(nil)).never_exists()
+		end)
+
+		test("calls generator functions", function()
+			expect(PropResolver.Parse(function()
+				return 42
+			end)).is(42)
+		end)
+
+		test("peeks Fusion state objects", function()
+			local scope = Fusion.scoped(Fusion)
+			local value = scope:Value(7)
+			expect(PropResolver.Parse(value)).is(7)
+			Fusion.doCleanup(scope)
+		end)
+
+		test("calls a generator held inside a Fusion state object", function()
+			local scope = Fusion.scoped(Fusion)
+			local value = scope:Value(function()
+				return "generated"
+			end)
+			expect(PropResolver.Parse(value)).is("generated")
+			Fusion.doCleanup(scope)
+		end)
+	end)
+
+	describe("ResolveRange", function()
+		test("passes plain numbers through", function()
+			expect(PropResolver.ResolveRange(3.5, Random.new(1))).is(3.5)
+		end)
+
+		test("rolls within a NumberRange", function()
+			local rng = Random.new(123)
+			for _ = 1, 20 do
+				local rolled = PropResolver.ResolveRange(NumberRange.new(2, 4), rng)
+				expect(rolled >= 2).is_true()
+				expect(rolled <= 4).is_true()
+			end
+		end)
+
+		test("is deterministic for the same seed", function()
+			local a = PropResolver.ResolveRange(NumberRange.new(0, 100), Random.new(42))
+			local b = PropResolver.ResolveRange(NumberRange.new(0, 100), Random.new(42))
+			expect(a).is(b)
+		end)
+
+		test("collapses a zero-width range", function()
+			expect(PropResolver.ResolveRange(NumberRange.new(5, 5), Random.new(1))).is(5)
+		end)
+	end)
+
+	describe("ResolveSpawnParams", function()
+		test("applies neutral defaults for empty props", function()
+			local params = PropResolver.ResolveSpawnParams({}, nil, Random.new(1))
+			expect(params.Size).is(Vector2.new(10, 10))
+			expect(params.Color3).is(Color3.new(1, 1, 1))
+			expect(params.Velocity).is(Vector2.zero)
+			expect(params.Transparency).is(0)
+			expect(params.Rotation).is(0)
+			expect(params.RotationSpeed).is(0)
+			expect(params.Image).never_exists()
+			expect(params.SizeScale).never_exists()
+			expect(params.LifeTime >= 2).is_true()
+			expect(params.LifeTime <= 4).is_true()
+		end)
+
+		test("uses prop values over defaults", function()
+			local params = PropResolver.ResolveSpawnParams({
+				Size = Vector2.new(20, 5),
+				Color3 = Color3.new(1, 0, 0),
+				Velocity = function()
+					return Vector2.new(1, 2)
+				end,
+				Transparency = 0.5,
+				LifeTime = 3,
+				Rotation = 45,
+				RotationSpeed = NumberRange.new(10, 10),
+				Image = "rbxassetid://1",
+			}, nil, Random.new(1))
+			expect(params.Size).is(Vector2.new(20, 5))
+			expect(params.Color3).is(Color3.new(1, 0, 0))
+			expect(params.Velocity).is(Vector2.new(1, 2))
+			expect(params.Transparency).is(0.5)
+			expect(params.LifeTime).is(3)
+			expect(params.Rotation).is(45)
+			expect(params.RotationSpeed).is(10)
+			expect(params.Image).is("rbxassetid://1")
+		end)
+
+		test("Fire overrides win over props", function()
+			local props = {
+				Size = Vector2.new(20, 5),
+				Transparency = 0.5,
+				Rotation = 45,
+			}
+			local overrides = {
+				Size = Vector2.new(1, 1),
+				Rotation = 90,
+			}
+			local params = PropResolver.ResolveSpawnParams(props, overrides, Random.new(1))
+			expect(params.Size).is(Vector2.new(1, 1))
+			expect(params.Rotation).is(90)
+			-- Untouched keys still come from props
+			expect(params.Transparency).is(0.5)
+		end)
+
+		test("keeps sequences unresolved for per-frame evaluation", function()
+			local transparencySequence = NumberSequence.new(0, 1)
+			local colorSequence = ColorSequence.new(Color3.new(), Color3.new(1, 1, 1))
+			local sizeSequence = NumberSequence.new(0.5, 1)
+			local params = PropResolver.ResolveSpawnParams({
+				Transparency = transparencySequence,
+				Color3 = colorSequence,
+				SizeScale = sizeSequence,
+			}, nil, Random.new(1))
+			expect(params.Transparency).is(transparencySequence)
+			expect(params.Color3).is(colorSequence)
+			expect(params.SizeScale).is(sizeSequence)
+		end)
+	end)
+end

--- a/lib/uiparticleemitter/src/Tests/UPE.SequenceUtil.spec.luau
+++ b/lib/uiparticleemitter/src/Tests/UPE.SequenceUtil.spec.luau
@@ -1,0 +1,88 @@
+--[[
+	Sequence evaluation coverage: NumberSequence and ColorSequence sampling at
+	edge times, exact keypoints, and mid-segment interpolation.
+]]
+
+return function(tiniest)
+	local SequenceUtil = require("../SequenceUtil")
+
+	local describe = tiniest.describe
+	local test = tiniest.test
+	local expect = tiniest.expect
+
+	local function approx(a: number, b: number): boolean
+		return math.abs(a - b) < 1e-6
+	end
+
+	describe("EvaluateNumberSequence", function()
+		local sequence = NumberSequence.new {
+			NumberSequenceKeypoint.new(0, 0),
+			NumberSequenceKeypoint.new(0.5, 10),
+			NumberSequenceKeypoint.new(1, 4),
+		}
+
+		test("returns the first keypoint at time <= 0", function()
+			expect(SequenceUtil.EvaluateNumberSequence(sequence, 0)).is(0)
+			expect(SequenceUtil.EvaluateNumberSequence(sequence, -1)).is(0)
+		end)
+
+		test("returns the last keypoint at time >= 1", function()
+			expect(SequenceUtil.EvaluateNumberSequence(sequence, 1)).is(4)
+			expect(SequenceUtil.EvaluateNumberSequence(sequence, 2)).is(4)
+		end)
+
+		test("returns exact values at interior keypoints", function()
+			expect(approx(SequenceUtil.EvaluateNumberSequence(sequence, 0.5), 10)).is_true()
+		end)
+
+		test("linearly interpolates between keypoints", function()
+			expect(approx(SequenceUtil.EvaluateNumberSequence(sequence, 0.25), 5)).is_true()
+			expect(approx(SequenceUtil.EvaluateNumberSequence(sequence, 0.75), 7)).is_true()
+		end)
+
+		test("handles a single-keypoint pair sequence", function()
+			local flat = NumberSequence.new(3)
+			expect(SequenceUtil.EvaluateNumberSequence(flat, 0.5)).is(3)
+		end)
+	end)
+
+	describe("EvaluateColorSequence", function()
+		local black = Color3.new(0, 0, 0)
+		local white = Color3.new(1, 1, 1)
+		local sequence = ColorSequence.new(black, white)
+
+		test("returns the first keypoint at time <= 0", function()
+			expect(SequenceUtil.EvaluateColorSequence(sequence, 0)).is(black)
+			expect(SequenceUtil.EvaluateColorSequence(sequence, -0.5)).is(black)
+		end)
+
+		test("returns the last keypoint at time >= 1", function()
+			expect(SequenceUtil.EvaluateColorSequence(sequence, 1)).is(white)
+			expect(SequenceUtil.EvaluateColorSequence(sequence, 1.5)).is(white)
+		end)
+
+		test("lerps between keypoints", function()
+			local mid = SequenceUtil.EvaluateColorSequence(sequence, 0.5)
+			expect(approx(mid.R, 0.5)).is_true()
+			expect(approx(mid.G, 0.5)).is_true()
+			expect(approx(mid.B, 0.5)).is_true()
+		end)
+
+		test("respects interior keypoint times", function()
+			local red = Color3.new(1, 0, 0)
+			local blue = Color3.new(0, 0, 1)
+			local threeKey = ColorSequence.new {
+				ColorSequenceKeypoint.new(0, red),
+				ColorSequenceKeypoint.new(0.8, blue),
+				ColorSequenceKeypoint.new(1, blue),
+			}
+			local atKeypoint = SequenceUtil.EvaluateColorSequence(threeKey, 0.8)
+			expect(approx(atKeypoint.B, 1)).is_true()
+			expect(approx(atKeypoint.R, 0)).is_true()
+
+			local mid = SequenceUtil.EvaluateColorSequence(threeKey, 0.4)
+			expect(approx(mid.R, 0.5)).is_true()
+			expect(approx(mid.B, 0.5)).is_true()
+		end)
+	end)
+end

--- a/lib/uiparticleemitter/src/Tests/UPE.Simulation.spec.luau
+++ b/lib/uiparticleemitter/src/Tests/UPE.Simulation.spec.luau
@@ -1,0 +1,202 @@
+--[[
+	Simulation coverage: deterministic physics stepping on plain particle
+	tables, normalized-lifetime math, and visual computation/application.
+]]
+
+return function(tiniest)
+	local Simulation = require("../Simulation")
+
+	local describe = tiniest.describe
+	local test = tiniest.test
+	local expect = tiniest.expect
+
+	local function approx(a: number, b: number): boolean
+		return math.abs(a - b) < 1e-4
+	end
+
+	local function approxV2(a: Vector2, b: Vector2): boolean
+		return approx(a.X, b.X) and approx(a.Y, b.Y)
+	end
+
+	-- Builds a minimal particle table; simulation fields only (no Instance
+	-- needed for Step/ComputeVisuals).
+	local function makeParticle(overrides: { [string]: any }?)
+		local particle = {
+			Instance = nil :: any,
+			IsImage = false,
+			Position = Vector2.zero,
+			Velocity = Vector2.zero,
+			LifeTime = 2,
+			InitialLifeTime = 2,
+			Rotation = 0,
+			RotationSpeed = 0,
+			BaseSize = Vector2.new(10, 10),
+			BaseColor = Color3.new(1, 1, 1),
+		}
+		for key, value in overrides or {} do
+			(particle :: any)[key] = value
+		end
+		return particle
+	end
+
+	local NO_FORCES = { Drag = 0, Gravity = Vector2.zero, Wind = nil }
+
+	describe("Step", function()
+		test("integrates position from velocity", function()
+			local particle = makeParticle { Velocity = Vector2.new(10, -5) }
+			Simulation.Step(particle, 1, NO_FORCES)
+			expect(approxV2(particle.Position, Vector2.new(10, -5))).is_true()
+		end)
+
+		test("applies drag as a per-second decay", function()
+			local particle = makeParticle { Velocity = Vector2.new(100, 0) }
+			Simulation.Step(particle, 0.1, { Drag = 0.5, Gravity = Vector2.zero })
+			expect(approxV2(particle.Velocity, Vector2.new(95, 0))).is_true()
+		end)
+
+		test("accumulates gravity", function()
+			local particle = makeParticle()
+			Simulation.Step(particle, 0.1, { Drag = 0, Gravity = Vector2.new(0, 500) })
+			expect(approxV2(particle.Velocity, Vector2.new(0, 50))).is_true()
+		end)
+
+		test("applies constant wind", function()
+			local particle = makeParticle()
+			Simulation.Step(particle, 0.5, { Drag = 0, Gravity = Vector2.zero, Wind = Vector2.new(20, 0) })
+			expect(approxV2(particle.Velocity, Vector2.new(10, 0))).is_true()
+		end)
+
+		test("samples functional wind at the particle position", function()
+			local sampledAt: Vector2? = nil
+			local particle = makeParticle { Position = Vector2.new(3, 4) }
+			Simulation.Step(particle, 1, {
+				Drag = 0,
+				Gravity = Vector2.zero,
+				Wind = function(pos: Vector2)
+					sampledAt = pos
+					return Vector2.new(1, 1)
+				end,
+			})
+			expect(sampledAt).is(Vector2.new(3, 4))
+			expect(approxV2(particle.Velocity, Vector2.new(1, 1))).is_true()
+		end)
+
+		test("advances rotation by rotation speed", function()
+			local particle = makeParticle { RotationSpeed = 90 }
+			Simulation.Step(particle, 0.5, NO_FORCES)
+			expect(approx(particle.Rotation, 45)).is_true()
+		end)
+
+		test("counts down lifetime", function()
+			local particle = makeParticle { LifeTime = 2 }
+			Simulation.Step(particle, 0.25, NO_FORCES)
+			expect(approx(particle.LifeTime, 1.75)).is_true()
+		end)
+	end)
+
+	describe("GetNormalizedLifetime", function()
+		test("is 0 at spawn and 1 at death", function()
+			expect(Simulation.GetNormalizedLifetime(makeParticle { LifeTime = 2, InitialLifeTime = 2 })).is(0)
+			expect(Simulation.GetNormalizedLifetime(makeParticle { LifeTime = 0, InitialLifeTime = 2 })).is(1)
+		end)
+
+		test("is 0.5 at half life and clamps out-of-range values", function()
+			expect(Simulation.GetNormalizedLifetime(makeParticle { LifeTime = 1, InitialLifeTime = 2 })).is(0.5)
+			expect(Simulation.GetNormalizedLifetime(makeParticle { LifeTime = -1, InitialLifeTime = 2 })).is(1)
+			expect(Simulation.GetNormalizedLifetime(makeParticle { LifeTime = 5, InitialLifeTime = 2 })).is(0)
+		end)
+	end)
+
+	describe("ComputeVisuals", function()
+		test("uses base values when no sequences are present", function()
+			local size, color, transparency = Simulation.ComputeVisuals(makeParticle {
+				BaseColor = Color3.new(1, 0, 0),
+				BaseTransparency = 0.25,
+			})
+			expect(size).is(Vector2.new(10, 10))
+			expect(color).is(Color3.new(1, 0, 0))
+			expect(transparency).is(0.25)
+		end)
+
+		test("defaults transparency to 0 when unset", function()
+			local _, _, transparency = Simulation.ComputeVisuals(makeParticle())
+			expect(transparency).is(0)
+		end)
+
+		test("evaluates sequences at the normalized lifetime", function()
+			local particle = makeParticle {
+				LifeTime = 1,
+				InitialLifeTime = 2,
+				SizeScaleSequence = NumberSequence.new(1, 2),
+				ColorSequence = ColorSequence.new(Color3.new(0, 0, 0), Color3.new(1, 1, 1)),
+				TransparencySequence = NumberSequence.new(0, 1),
+				BaseColor = nil,
+			}
+			local size, color, transparency = Simulation.ComputeVisuals(particle)
+			expect(approxV2(size, Vector2.new(15, 15))).is_true()
+			expect(approx(color.R, 0.5)).is_true()
+			expect(approx(transparency, 0.5)).is_true()
+		end)
+	end)
+
+	describe("ApplyVisuals", function()
+		test("writes position, color and transparency to a Frame", function()
+			local frame = Instance.new("Frame")
+			local particle = makeParticle {
+				Instance = frame,
+				Position = Vector2.new(100, 250),
+				BaseColor = Color3.new(0, 1, 0),
+				BaseTransparency = 0.5,
+			}
+			Simulation.ApplyVisuals(particle, 50)
+			expect(frame.Position).is(UDim2.fromOffset(100, 200))
+			expect(frame.BackgroundColor3).is(Color3.new(0, 1, 0))
+			expect(frame.BackgroundTransparency).is(0.5)
+			frame:Destroy()
+		end)
+
+		test("writes image properties for ImageLabel particles", function()
+			local imageLabel = Instance.new("ImageLabel")
+			local particle = makeParticle {
+				Instance = imageLabel,
+				IsImage = true,
+				BaseColor = Color3.new(0, 0, 1),
+				BaseTransparency = 0.75,
+			}
+			Simulation.ApplyVisuals(particle, 0)
+			expect(imageLabel.ImageColor3).is(Color3.new(0, 0, 1))
+			expect(imageLabel.ImageTransparency).is(0.75)
+			imageLabel:Destroy()
+		end)
+
+		test("only writes Rotation when the particle spins", function()
+			local frame = Instance.new("Frame")
+			frame.Rotation = 15
+			local still = makeParticle { Instance = frame, Rotation = 99, RotationSpeed = 0 }
+			Simulation.ApplyVisuals(still, 0)
+			expect(frame.Rotation).is(15)
+
+			local spinning = makeParticle { Instance = frame, Rotation = 30, RotationSpeed = 10 }
+			Simulation.ApplyVisuals(spinning, 0)
+			expect(frame.Rotation).is(30)
+			frame:Destroy()
+		end)
+
+		test("only writes Size when a size sequence is present", function()
+			local frame = Instance.new("Frame")
+			frame.Size = UDim2.fromOffset(1, 1)
+			local static = makeParticle { Instance = frame }
+			Simulation.ApplyVisuals(static, 0)
+			expect(frame.Size).is(UDim2.fromOffset(1, 1))
+
+			local animated = makeParticle {
+				Instance = frame,
+				LifeTime = 0,
+				SizeScaleSequence = NumberSequence.new(2),
+			}
+			Simulation.ApplyVisuals(animated, 0)
+			expect(frame.Size).is(UDim2.fromOffset(20, 20))
+			frame:Destroy()
+		end)
+	end)
+end

--- a/lib/uiparticleemitter/src/Types.luau
+++ b/lib/uiparticleemitter/src/Types.luau
@@ -47,6 +47,7 @@ export type EmitterProps = {
 
 	MaxParticles: UsedAs<number>?,
 	CleanupParticlesImmediately: UsedAs<boolean>?,
+	MaintainRelativePosition: UsedAs<boolean>?,
 	Seed: number?,
 }
 

--- a/lib/uiparticleemitter/src/Types.luau
+++ b/lib/uiparticleemitter/src/Types.luau
@@ -1,0 +1,132 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	Shared type definitions for UIParticleEmitter.
+]]
+
+local Fusion = require("../Fusion")
+
+export type UsedAs<T> = Fusion.UsedAs<T>
+export type Scope<T> = Fusion.Scope<T>
+
+-- A value that may be a constant, a Fusion state object, or (once unwrapped)
+-- a generator function producing a fresh value per particle.
+export type Getter<T> = UsedAs<T | () -> T>
+
+-- Wind may be a constant force or a function sampling the wind at a position.
+export type WindSource = Vector2 | (pos: Vector2) -> Vector2
+
+--------------------------------------------------------------------------------
+-- Public API types
+--------------------------------------------------------------------------------
+
+export type EmitterProps = {
+	Parent: UsedAs<Instance>?,
+	SpawnAreaPosition: UsedAs<UDim2>?,
+	SpawnAreaAnchorPoint: UsedAs<Vector2>?,
+	SpawnAreaSize: UsedAs<UDim2>?,
+
+	Enabled: UsedAs<boolean>?,
+	Visible: UsedAs<boolean>?,
+	TimeScale: UsedAs<number>?,
+	Rate: Getter<number>?,
+
+	Drag: UsedAs<number>?,
+	Gravity: UsedAs<number>?,
+	Wind: UsedAs<WindSource>?,
+
+	Velocity: Getter<Vector2>?,
+	Size: Getter<Vector2>?,
+	SizeScale: Getter<number | NumberSequence>?,
+	Color3: Getter<Color3 | ColorSequence>?,
+	Image: Getter<string>?,
+	Transparency: Getter<number | NumberSequence>?,
+	LifeTime: Getter<number | NumberRange>?,
+	Rotation: Getter<number | NumberRange>?,
+	RotationSpeed: Getter<number | NumberRange>?,
+
+	MaxParticles: UsedAs<number>?,
+	CleanupParticlesImmediately: UsedAs<boolean>?,
+	Seed: number?,
+}
+
+export type FireConfig = {
+	Amount: Getter<number>?,
+
+	Size: Getter<Vector2>?,
+	SizeScale: Getter<number | NumberSequence>?,
+	Color3: Getter<Color3 | ColorSequence>?,
+	Image: Getter<string>?,
+	Transparency: Getter<number | NumberSequence>?,
+	LifeTime: Getter<number | NumberRange>?,
+	Velocity: Getter<Vector2>?,
+	Rotation: Getter<number | NumberRange>?,
+	RotationSpeed: Getter<number | NumberRange>?,
+
+	-- Optional spawn area overrides
+	SpawnAreaPosition: Getter<UDim2>?,
+	SpawnAreaAbsolutePosition: Getter<Vector2>?,
+	SpawnAreaAnchorPoint: Getter<Vector2>?,
+	SpawnAreaSize: Getter<UDim2>?,
+}
+
+export type UIParticleEmitter = {
+	UI: Frame,
+	Fire: (self: UIParticleEmitter, config: FireConfig?) -> (),
+	Stop: (self: UIParticleEmitter) -> (),
+	Clear: (self: UIParticleEmitter) -> (),
+	GetParticleCount: (self: UIParticleEmitter) -> number,
+}
+
+--------------------------------------------------------------------------------
+-- Internal types
+--------------------------------------------------------------------------------
+
+-- Fully-resolved per-particle spawn parameters (no getters/state objects left).
+export type SpawnParams = {
+	Size: Vector2,
+	SizeScale: (number | NumberSequence)?,
+	Color3: Color3 | ColorSequence,
+	Image: string?,
+	Velocity: Vector2,
+	LifeTime: number,
+	Transparency: number | NumberSequence,
+	Rotation: number,
+	RotationSpeed: number,
+}
+
+-- Resolved spawn area overrides for a Fire() burst.
+export type SpawnAreaOverrides = {
+	SpawnAreaPosition: UDim2?,
+	SpawnAreaAbsolutePosition: Vector2?,
+	SpawnAreaAnchorPoint: Vector2?,
+	SpawnAreaSize: UDim2?,
+}
+
+-- A live particle. Numeric/simulation fields are plain data so the physics
+-- step can be tested without touching the Instance.
+export type Particle = {
+	Instance: GuiObject,
+	IsImage: boolean,
+	Position: Vector2,
+	Velocity: Vector2,
+	LifeTime: number,
+	InitialLifeTime: number,
+	Rotation: number,
+	RotationSpeed: number,
+	BaseSize: Vector2,
+	SizeScaleSequence: NumberSequence?,
+	BaseColor: Color3?,
+	ColorSequence: ColorSequence?,
+	TransparencySequence: NumberSequence?,
+	BaseTransparency: number?,
+}
+
+-- Per-step environment for the physics simulation.
+export type SimulationEnv = {
+	Drag: number,
+	Gravity: Vector2,
+	Wind: WindSource?,
+}
+
+return nil

--- a/lib/uiparticleemitter/src/UIParticleEmitter.story.luau
+++ b/lib/uiparticleemitter/src/UIParticleEmitter.story.luau
@@ -1,0 +1,88 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[[
+	UI Labs story demonstrating UIParticleEmitter with the Confetti preset:
+	continuous spawning, live physics controls, noise-driven wind, and
+	optional periodic bursts.
+
+	Note: this repo has no story runner; the story ships with the package for
+	use in consuming projects with UI Labs installed.
+]]
+
+local Fusion = require("../Fusion")
+local UIParticleEmitter = require(script.Parent :: any)
+
+local peek = Fusion.peek
+
+local CONTROLS = {
+	Enabled = true,
+	Visible = true,
+	Gravity = 500,
+	Drag = 0.95,
+	Rate = 30,
+	TimeScale = 1,
+	WindStrength = 50,
+	WindNoiseScale = 0.01,
+	VerticalForceMin = 200,
+	VerticalForceMax = 600,
+	HorizontalForceMin = -100,
+	HorizontalForceMax = 100,
+	BurstFiring = false,
+}
+
+return {
+	fusion = Fusion,
+	controls = CONTROLS,
+	story = function(props)
+		local controls = props.controls
+		local scope = props.scope
+		local rng = Random.new()
+
+		local emitter = UIParticleEmitter(
+			scope,
+			UIParticleEmitter.Presets.Confetti {
+				Parent = props.target,
+				Enabled = controls.Enabled,
+				Visible = controls.Visible,
+				Gravity = controls.Gravity,
+				Drag = controls.Drag,
+				TimeScale = controls.TimeScale,
+				Rate = controls.Rate,
+				LifeTime = NumberRange.new(2, 5),
+				RotationSpeed = NumberRange.new(-200, 200),
+				Size = function()
+					local length = rng:NextNumber(12, 25)
+					return Vector2.new(length, length * rng:NextNumber(0.4, 0.6))
+				end,
+				Velocity = function()
+					return Vector2.new(
+						rng:NextNumber(peek(controls.HorizontalForceMin), peek(controls.HorizontalForceMax)),
+						-rng:NextNumber(peek(controls.VerticalForceMin), peek(controls.VerticalForceMax))
+					)
+				end,
+				Wind = function(pos: Vector2)
+					-- Noise-driven wind field for a natural tumble
+					local time = os.clock()
+					local noiseScale = peek(controls.WindNoiseScale)
+					local strength = peek(controls.WindStrength)
+					local noiseX = math.noise(pos.X * noiseScale, pos.Y * noiseScale, time * 0.5)
+					local noiseY = math.noise(pos.X * noiseScale + 100, pos.Y * noiseScale + 100, time * 0.5)
+					return Vector2.new(noiseX * strength, noiseY * strength)
+				end,
+			}
+		)
+
+		-- Periodic bursts while the BurstFiring control is on
+		local burstThread = task.spawn(function()
+			while true do
+				task.wait(3)
+				if peek(controls.BurstFiring) then
+					emitter:Fire { Amount = 50 }
+				end
+			end
+		end)
+		table.insert(scope, function()
+			task.cancel(burstThread)
+		end)
+	end,
+}

--- a/lib/uiparticleemitter/src/UIParticleEmitterNestedParent.story.luau
+++ b/lib/uiparticleemitter/src/UIParticleEmitterNestedParent.story.luau
@@ -1,0 +1,111 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 07, 2026
+--[[
+	UI Labs story for visually verifying spawn-area geometry when the
+	emitter is parented several GuiObjects deep under the LayerCollector, and
+	when Fire() overrides only part of the spawn area (e.g. just Position).
+
+	A green outline marks the expected spawn rectangle -- bursts should
+	always land inside it, regardless of nesting depth or which spawn-area
+	fields are overridden. This exercises the fix in
+	Emitter.computeSpawnArea: a non-overridden spawn-area field must fall
+	back to the UI's own AbsolutePosition/AbsoluteSize, not be re-resolved
+	against the (unrelated) LayerCollector's size.
+]]
+
+local Fusion = require("../Fusion")
+local UIParticleEmitter = require(script.Parent :: any)
+
+local peek = Fusion.peek
+
+local CONTROLS = {
+	Enabled = false,
+	UsePositionOverride = false, -- Fire() overrides only SpawnAreaPosition; Size/Anchor must still come from the nested Frame
+	BurstAmount = 40,
+	MaintainRelativePosition = false,
+}
+
+return {
+	fusion = Fusion,
+	controls = CONTROLS,
+	story = function(props)
+		local controls = props.controls
+		local scope = props.scope
+
+		-- Nest the emitter two Frames deep, each sized differently than the
+		-- ScreenGui, so a spawn-area bug that resolves the UI's own
+		-- Size/Position against the LayerCollector (instead of its real
+		-- Parent) becomes visually obvious: particles would spawn far
+		-- outside the drawn outline (or collapse to a single point).
+		local outer = Instance.new("Frame")
+		outer.Name = "NestedContainer_Outer"
+		outer.AnchorPoint = Vector2.new(0.5, 0.5)
+		outer.Position = UDim2.fromScale(0.5, 0.5)
+		outer.Size = UDim2.fromOffset(600, 450)
+		outer.BackgroundTransparency = 1
+		outer.Parent = props.target
+		table.insert(scope, outer)
+
+		local inner = Instance.new("Frame")
+		inner.Name = "NestedContainer_Inner"
+		inner.AnchorPoint = Vector2.new(0.5, 0.5)
+		inner.Position = UDim2.fromScale(0.5, 0.5)
+		inner.Size = UDim2.fromScale(0.35, 0.4) -- 210x180, a fraction of `outer` -- NOT of the ScreenGui
+		inner.BackgroundTransparency = 1
+		inner.Parent = outer
+
+		-- Visible outline marking the expected spawn rectangle.
+		local outline = Instance.new("Frame")
+		outline.Name = "ExpectedSpawnAreaOutline"
+		outline.Size = UDim2.fromScale(1, 1)
+		outline.BackgroundTransparency = 1
+		outline.Parent = inner
+		local stroke = Instance.new("UIStroke")
+		stroke.Thickness = 2
+		stroke.Color = Color3.fromRGB(0, 255, 0)
+		stroke.Parent = outline
+
+		local emitter = UIParticleEmitter(scope, {
+			Parent = inner,
+			SpawnAreaSize = UDim2.fromScale(1, 1), -- exactly fills `inner`
+			Enabled = controls.Enabled,
+			Rate = 15,
+			Color3 = Color3.fromRGB(0, 255, 0),
+			LifeTime = NumberRange.new(1, 1.5),
+			Velocity = Vector2.zero,
+			MaintainRelativePosition = controls.MaintainRelativePosition,
+			-- Gravity = 0,
+		})
+
+		-- Periodic bursts so the story is useful even with Enabled off.
+		local moveThread = task.spawn(function()
+			while true do
+				task.wait()
+				inner.Position = UDim2.fromScale(0.5 + math.sin(os.clock()) / 2, 0.5)
+			end
+		end)
+		local burstThread = task.spawn(function()
+			while true do
+				task.wait(1.5)
+				local amount = peek(controls.BurstAmount)
+				if peek(controls.UsePositionOverride) then
+					-- Only Position is overridden here (to the same spot the
+					-- Frame already occupies) -- Size/Anchor must still fall
+					-- back to `inner`'s own AbsoluteSize, keeping bursts
+					-- inside the green outline.
+					emitter:Fire {
+						Amount = amount,
+						SpawnAreaAbsolutePosition = inner.AbsolutePosition + inner.AbsoluteSize / 2,
+						SpawnAreaAbsoluteSize = Vector2.zero,
+					}
+				else
+					emitter:Fire { Amount = amount }
+				end
+			end
+		end)
+		table.insert(scope, function()
+			task.cancel(burstThread)
+			task.cancel(moveThread)
+		end)
+	end,
+}

--- a/lib/uiparticleemitter/src/UIParticleEmitterNestedParent.story.luau
+++ b/lib/uiparticleemitter/src/UIParticleEmitterNestedParent.story.luau
@@ -96,7 +96,7 @@ return {
 					emitter:Fire {
 						Amount = amount,
 						SpawnAreaAbsolutePosition = inner.AbsolutePosition + inner.AbsoluteSize / 2,
-						SpawnAreaAbsoluteSize = Vector2.zero,
+						SpawnAreaSize = UDim2.fromOffset(0, 0),
 					}
 				else
 					emitter:Fire { Amount = amount }

--- a/lib/uiparticleemitter/src/init.luau
+++ b/lib/uiparticleemitter/src/init.luau
@@ -18,6 +18,9 @@
 	  a pool shared by all emitters on the same LayerCollector for high spawn
 	  rates
 	- `MaxParticles` cap (new spawns are dropped at the cap)
+	- `MaintainRelativePosition` makes live particles ride along with the
+	  emitter as it moves, instead of staying where they spawned in screen
+	  space (default off)
 	- Particle management with `:Stop()`, `:Clear()`, and `:GetParticleCount()`
 	- Presets via `UIParticleEmitter.Presets` (e.g. `Presets.Confetti`)
 

--- a/lib/uiparticleemitter/src/init.luau
+++ b/lib/uiparticleemitter/src/init.luau
@@ -15,7 +15,8 @@
 	  color, and size over a particle's lifetime (keypoint envelopes are
 	  ignored; values interpolate linearly between keypoints)
 	- Solid color (Frame) or image (ImageLabel) particles, recycled through
-	  an internal pool for high spawn rates
+	  a pool shared by all emitters on the same LayerCollector for high spawn
+	  rates
 	- `MaxParticles` cap (new spawns are dropped at the cap)
 	- Particle management with `:Stop()`, `:Clear()`, and `:GetParticleCount()`
 	- Presets via `UIParticleEmitter.Presets` (e.g. `Presets.Confetti`)

--- a/lib/uiparticleemitter/src/init.luau
+++ b/lib/uiparticleemitter/src/init.luau
@@ -1,0 +1,86 @@
+-- Authors: Logan Hunt (Raildex)
+-- July 06, 2026
+--[=[
+	@class UIParticleEmitter
+
+	A Fusion 0.3 component that emits 2D particles (Frames or ImageLabels),
+	similar to Roblox's ParticleEmitter but for ScreenGuis. Particles can
+	spawn continuously while `Enabled`, or on demand via `:Fire()`.
+
+	Features:
+	- Continuous spawning based on `Rate`, plus manual bursts with `:Fire()`
+	- Physics simulation with gravity, drag, wind (constant or positional
+	  function), and rotation
+	- `NumberSequence` / `ColorSequence` support for animating transparency,
+	  color, and size over a particle's lifetime (keypoint envelopes are
+	  ignored; values interpolate linearly between keypoints)
+	- Solid color (Frame) or image (ImageLabel) particles, recycled through
+	  an internal pool for high spawn rates
+	- `MaxParticles` cap (new spawns are dropped at the cap)
+	- Particle management with `:Stop()`, `:Clear()`, and `:GetParticleCount()`
+	- Presets via `UIParticleEmitter.Presets` (e.g. `Presets.Confetti`)
+
+	Most particle props accept a constant, a Fusion state object, or a
+	generator function called once per particle spawn.
+
+	By design, destroying the emitter's scope does **not** kill live
+	particles: spawning stops, but existing particles finish their natural
+	lifetime before everything cleans itself up. Pass
+	`CleanupParticlesImmediately = true` to destroy them instantly instead.
+
+	Usage:
+	```lua
+	local scope = Fusion.scoped(Fusion)
+
+	-- Neutral particles with a fade-out
+	local emitter = UIParticleEmitter(scope, {
+		Parent = screenGui,
+		SpawnAreaPosition = UDim2.fromScale(0.5, 0.5),
+		Enabled = true,
+		Rate = 20,
+		Velocity = function()
+			return Vector2.new(math.random(-50, 50), -math.random(100, 200))
+		end,
+		Transparency = NumberSequence.new({
+			NumberSequenceKeypoint.new(0, 0),
+			NumberSequenceKeypoint.new(0.8, 0),
+			NumberSequenceKeypoint.new(1, 1),
+		}),
+	})
+
+	-- Confetti preset with a manual burst
+	local confetti = UIParticleEmitter(scope, UIParticleEmitter.Presets.Confetti({
+		Parent = screenGui,
+		Enabled = false,
+	}))
+	confetti:Fire({ Amount = 100 })
+	```
+]=]
+
+local Emitter = require("@self/Emitter")
+local Presets = require("@self/Presets")
+local Types = require("@self/Types")
+
+export type Getter<T> = Types.Getter<T>
+export type EmitterProps = Types.EmitterProps
+export type FireConfig = Types.FireConfig
+export type UIParticleEmitter = Types.UIParticleEmitter
+
+--[=[
+	@within UIParticleEmitter
+	@prop Presets Presets
+	@readonly
+
+	Prop-table factories for common looks. Currently ships
+	`Presets.Confetti(overrides?)`.
+]=]
+
+local UIParticleEmitter = setmetatable({
+	Presets = Presets,
+}, {
+	__call = function(_, scope: Types.Scope<any>, props: EmitterProps): UIParticleEmitter
+		return Emitter.new(scope, props) :: any
+	end,
+})
+
+return UIParticleEmitter

--- a/lib/uiparticleemitter/wally.toml
+++ b/lib/uiparticleemitter/wally.toml
@@ -1,0 +1,17 @@
+[package]
+name = "raild3x/uiparticleemitter"
+description = "FusionComponent for emitting 2d images"
+authors = ["Logan Hunt (Raildex)"]
+version = "0.1.0"
+license = "MIT"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[custom]
+# The properly capitalized and spaced name of the library
+formattedName = "UIParticleEmitter"
+# The intro page for the documentation
+docsLink = "UIParticleEmitter"
+
+[dependencies]
+Fusion = "elttob/fusion@0.3.0"

--- a/lib/uiparticleemitter/wally.toml
+++ b/lib/uiparticleemitter/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raild3x/uiparticleemitter"
-description = "FusionComponent for emitting 2d images"
+description = "FusionComponent for emitting 2D images"
 authors = ["Logan Hunt (Raildex)"]
 version = "0.1.0"
 license = "MIT"

--- a/moonwave.toml
+++ b/moonwave.toml
@@ -77,5 +77,9 @@ section = "Admin Commands [Cmdr]"
 classes = ["CmdrHandler", "PermissionsHandler", "CmdrServer", "CmdrClient", "CmdrTypes"]
 
 [[classOrder]]
+section = "UIParticleEmitter"
+classes = ["UIParticleEmitter"]
+
+[[classOrder]]
 section = "Data Structures"
 classes = ["Queue", "Heap", "LooseTightDoubleGrid", "Quadtree"]


### PR DESCRIPTION
Introduce a new Fusion-based `UIParticleEmitter` package with spawning, simulation, pooling, presets, and story support. The package includes focused tests for emitters, prop resolution, sequence evaluation, and simulation behavior, and registers the new module in the README and Moonwave docs.